### PR TITLE
NCT Update

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -28,5 +28,5 @@
    * Use global.d.ts instead of compilerOptions.types
    * to avoid limiting type declarations.
    */
-  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte", "src/lib/helpers/cardDataModifier.cjs"]
 }

--- a/public/data/cardShowcase.json
+++ b/public/data/cardShowcase.json
@@ -17,7 +17,7 @@
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725057041/oexla_ordinary_exo_lay.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650008/oexla_ordinary_exo_lay_d2u3fo.png",
     "showcaseByRarity": "true"
   },
   {
@@ -28,7 +28,7 @@
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725057036/oexka_ordinary_exo_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649993/oexka_ordinary_exo_kai_kucdzd.png"
   },
   {
     "id": "oexsh",
@@ -38,7 +38,7 @@
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725057045/oexsh_ordinary_exo_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650029/oexsh_ordinary_exo_sehun_qjzqpk.png"
   },
   {
     "id": "uexcn",
@@ -48,7 +48,7 @@
     "group": "EXO",
     "types": ["Lightning"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725060678/uexcn_unordinary_exo_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650257/uexcn_unordinary_exo_chen_tu3zuq.png"
   },
   {
     "id": "uexbh",
@@ -58,7 +58,7 @@
     "group": "EXO",
     "types": ["Lightning"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725060672/uexbh_unordinary_exo_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650212/uexbh_unordinary_exo_baekhyun_kviurk.png"
   },
   {
     "id": "uexxm",
@@ -68,7 +68,7 @@
     "group": "EXO",
     "types": ["Lightning"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725061107/uexxm_unordinary_exo_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650418/uexxm_unordinary_exo_xiumin_ubtzwi.png"
   },
   {
     "id": "r2excy",
@@ -78,7 +78,7 @@
     "group": "EXO",
     "types": ["Darkness"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725057588/r2excy_rare_exo_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653105/r2excy_rare_exo_chanyeol_t6cvh4.png"
   },
   {
     "id": "r2exxm",
@@ -88,7 +88,7 @@
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725058167/r2exxm_rare_exo_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653212/r2exxm_rare_exo_xiumin_jbjogi.png"
   },
   {
     "id": "rexdo",
@@ -98,7 +98,7 @@
     "group": "EXO",
     "types": ["Dragon"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725058187/rexdo_rare_exo_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650591/rexdo_rare_exo_do_b6txzw.png"
   },
   {
     "id": "s2eobh",
@@ -108,7 +108,7 @@
     "group": "EXO",
     "types": ["Metal"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725058222/s2eobh_special_exo_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653357/s2eobh_special_exo_baekhyun_wcur00.png"
   },
   {
     "id": "s2eodo",
@@ -118,7 +118,7 @@
     "group": "EXO",
     "types": ["Metal"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725058908/s2eodo_special_exo_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653475/s2eodo_special_exo_do_tmae4t.png"
   },
   {
     "id": "seoka",
@@ -128,7 +128,7 @@
     "group": "EXO",
     "types": ["Lightning"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725059607/seoka_special_exo_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650902/seoka_special_exo_kai_hugsor.png"
   },
   {
     "id": "e2exsh",
@@ -138,7 +138,7 @@
     "group": "EXO",
     "types": ["Water"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977782/e2exsh_extraordinary_exo_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653945/e2exsh_extraordinary_exo_sehun_pr4c9o.png"
   },
   {
     "id": "e2excy",
@@ -148,7 +148,7 @@
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977870/e2excy_extraordinary_exo_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653818/e2excy_extraordinary_exo_chanyeol_i59uax.png"
   },
   {
     "id": "e2exsu",
@@ -158,7 +158,7 @@
     "group": "EXO",
     "types": ["Fairy"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977950/e2exsu_extraordinary_exo_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653962/e2exsu_extraordinary_exo_suho_vpjffr.png"
   },
   {
     "id": "psesu",
@@ -168,7 +168,7 @@
     "group": "EXO",
     "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978032/psesu_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319419/psesu_priceless_stardust%20event_suho.png"
   },
   {
     "id": "cdyshn",
@@ -178,7 +178,7 @@
     "group": "EXO",
     "types": ["Psychic"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978242/cdyshn_priceless_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321982/cdyshn_priceless_candy_sehun.png"
   },
   {
     "id": "psela",
@@ -188,7 +188,7 @@
     "group": "EXO",
     "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978346/psela_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319384/psela_priceless_stardust%20event_lay.png"
   },
   {
     "id": "anexch",
@@ -198,7 +198,7 @@
     "group": "EXO",
     "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978425/anexch_altair_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318750/anexch_altair_anniversary_chen.png"
   },
   {
     "id": "starsuho",
@@ -208,7 +208,7 @@
     "group": "EXO",
     "types": ["Psychic"],
     "rarity": "Amazing Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724999594/starsuho_altair_suho.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322390/starsuho_altair_starry%20night_suho.png",
     "mask": "",
     "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png"
   },
@@ -220,6 +220,6 @@
     "group": "EXO",
     "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978506/12yrsxm_altair_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318409/12yrsxm_altair_anniversary_xiumin.png"
   }
 ]

--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -97,7 +97,7 @@
 			<p><nav> <a href="/#/update" style="color: springgreen">Check the update log</a> </nav>
 
 			<p class="small">
-				Latest card library update: <strong>06/10/2024</strong>  <br />
+				Latest card library update: <strong>19/10/2024</strong>  <br />
 				All EXO cards are up-to-date.
 					<br>
 					<a href="https://github.com/mrlimeshark/suho-cards-collection">Source code is in the repository</a>.
@@ -119,11 +119,11 @@
 			<p>
 				
 				 <br/>
-				 EVENT DROP: <strong>Priceless</strong> sapchn (no longer droppable)<br />
-				 REGULAR RELEASE: <strong>Ordinary</strong> o2slsu, <strong>Unordinary</strong> u2slsu, <strong>Rare</strong> r2slsu,
-				 <strong>Special</strong> s2slsu, <strong>Extraordinary</strong> e2slsu
+				 <strong>NCT joins our interactive collection!</strong><br />
+				 NCT127, NCT Dream, WayV, KUN&XIAOJUN, NCT WISH, Soloist, and all event cards are now searchable. <br />
+				 Typing <strong>only</strong> the 'NCT' keyword will fetch every aforementioned card, so specific keywords are preferred for your convenience.
 			</p>
-			<h3>Good luck dropping!</h3>
+			<h3></h3>
 
 			<CardList>
 				{#if isLoading}

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -7,6 +7,8 @@
 
   import EXOLib from "./lib/database/exoLibrary.json";
   import SVTLib from "./lib/database/svtLibrary.json";
+  import NCTLib from "./lib/database/nctLibrary.json";
+  import SupMLib from "./lib/database/superMLibrary.json";
 
 	export let query = "";
   let placeholderText = "";
@@ -27,7 +29,10 @@
   //Don't do 'let something = getCards()'
 
   // Combine the multiple libraries
-  const fullLibrary = [...EXOLib, ...SVTLib];
+  const fullLibrary = [...EXOLib, ...SupMLib, ...SVTLib, ...NCTLib];
+
+  // For testing
+  //const testLibrary = [...EXOLib, ...NCTLib];
 
 
   const generateRandomPlaceholder = () => {
@@ -76,7 +81,7 @@
 
 
           try {
-
+            // CHANGE LIBRARY HERE *********************************
             const filteredCards = search(fullLibrary, query);
             isError = false;
 

--- a/src/UpdateLog.svelte
+++ b/src/UpdateLog.svelte
@@ -34,21 +34,28 @@
 	<header>
 
 
-		<h1 id="⚓-top">SUHO Cards Collection UPDATE LOG <sup>06/10/2024</sup>
+		<h1 id="⚓-top">SUHO Cards Collection UPDATE LOG <sup>19/10/2024</sup>
 		</h1>
 
 		<section class="intro" id="⚓-intro">
 
 
-			<h2>Latest major update: <strong>11/09/2024</strong></h2> <br/>
+			<h2>Latest major update: <strong>19/10/2024</strong></h2> <br/>
 			<p>
-				<mark>Please welcome the newest addition to our card database: Seventeen!</mark> 🎉 <br/>
-				Seventeen cards have many inconsistent search keywords especially with duo cards (JeongCheol, SoonHoon, etc.).
-				Worry not. Our flexible search system on this website has fixed such a problem. <br/>
+				<mark>NCT is now proud citizens of our card database!</mark> 🎉 <br/>
+				NCT has multiple subgroups, and some members of NCT are part of more than one subgroup.
+				For instance, both NCT127 and NCT Dream have Mark cards, and obviously, the search system of the SUHO bot
+				is not quite flexible for looking up every Mark card at once. <br/>
+				Fortunately, our database has QOL features to fix such a problem!<br/><br/>
 				
-				Simply use keywords like "<strong>Jeonghan</strong>," "<strong>S.Coups</strong>," or "<strong>JeongCheol</strong>" to quickly find the <strong>ansvjc JeongCheol</strong> card, for instance.
+				<mark>All NCT cards, NCT127, NCT Dream, WayV, KUN-XIAOJUN, NCT WISH, Soloist, and event cards, are available.</mark><br/>
+				NCT WISH group has not been officially added to the SUHO bot, but using the keyword <strong>"WISH"</strong> will still show up NCT WISH members.<br/>
 
-				<br/> We are certain that everyone will be delighted with this update. :) <br/>
+				<br/><strong>Usable keywords: nct, nct127, 127, nct dream, dream, wayv, nct wish, wish, group(for group photos), soloist, card codes, event names, etc.</strong><br/>
+				Any keywords one considers reasonable should work.<br/>
+
+				<br/>The full update log is available below.
+				<br/> Have a great day, everyone.<br/>
 			</p>
 		</section>
 
@@ -67,6 +74,52 @@
 			</p>	
 		</section>
 	</header>
+		<h2 id="⚓-log3">
+				NCT & QOL update <sup>19/10/2024</sup>
+		</h2>
+		<p>
+			<br/>
+			<mark>NCT is now proud citizens of our card database!</mark> 🎉 <br/>
+			<strong>Available cards: NCT127, NCT Dream, WayV, KUN&XIAOJUN, NCT WISH, Soloist, and event cards.</strong><br/>
+			
+			<br/><strong>Usable keywords: nct, nct127, 127, nct dream, dream, wayv, nct wish, wish, group(for group photos), soloist, card codes, event names, etc.</strong><br/>
+			Any search keywords one considers reasonable should work.<br/>
+			
+			<br/><mark>Other QOL updates:</mark><br/>
+			- Keywords are not case-sensitive; 'EXO' or 'exo' do not matter.<br/>
+			It has always been like this, but this feature has not been explicitly stated.<br/><br/>
+			
+			- <strong>p0rtr4it Altair Suho</strong> card is now searchable using the keyword <strong>'portrait'</strong><br/><br/>
+			
+			- EXO-CBX cards are now searchable using the keyword <strong>'CBX'</strong><br/><br/>
+
+			- All Evil Event cards are now searchable using the keyword <strong>'evil'</strong><br/><br/>
+
+			- All Fairies cards are now searchable using the keywords <strong>'fairy'</strong> and <strong>'fairies'</strong><br/><br/>
+
+			- All Xmas-related cards are now searchable using the keyword <strong>'xmas'</strong><br/>
+			Adding <strong>'fanmade'</strong> or <strong>'xmas23'</strong> narrows the search result.<br/><br/>
+
+
+			<br/> This is our biggest update yet! <br/>
+		</p>
+		<h3></h3>
+
+
+		<h2 id="⚓-log2">
+				Seventeen update <sup>11/09/2024</sup>
+		</h2>
+		<p>
+			<br/>
+			<mark>Please welcome the newest addition to our card database: Seventeen!</mark> 🎉 <br/>
+			Seventeen cards have many inconsistent search keywords especially with duo cards (JeongCheol, SoonHoon, etc.).
+			Worry not. Our flexible search system on this website has fixed such a problem. <br/>
+			
+			Simply use keywords like "<strong>Jeonghan</strong>," "<strong>S.Coups</strong>," or "<strong>JeongCheol</strong>" to quickly find the <strong>ansvjc JeongCheol</strong> card, for instance.
+
+			<br/> We are certain that everyone will be delighted with this update. :) <br/>
+		</p>
+
 
 		<h2 id="⚓-log1">
 				Grand opening! <sup>31/08/2024</sup>
@@ -77,6 +130,5 @@
 			Everyone can view all EXO cards faster than ever with 3D interactions and pretty holofoils! <br/>
 			New cards are going to be added whenever there is any update.
 		</p>
-		<h3></h3>
 
 </main>

--- a/src/latestCards.json
+++ b/src/latestCards.json
@@ -1,62 +1,34 @@
 [    
-{
-  "id": "sapchn",
-  "cardRarity": "Priceless",
-  "cardGroup": "Sapphire",
-  "name": "Chen",
-  "group": "EXO",
-  "types": ["Metal"],
-  "rarity": "Rare Shiny",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1727630926/sapchn_priceless_sapphire_chen.png"
-},
-{
-  "id": "o2slsu",
-  "cardRarity": "Ordinary",
-  "cardGroup": "Soloist",
-  "name": "Suho",
-  "group": "EXO",
-  "types": ["Metal"],
-  "rarity": "Common",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154769/o2slsu_ordinary_soloist_suho_hmzswz.png"
-},
-{
-  "id": "u2slsu",
-  "cardRarity": "Unordinary",
-  "cardGroup": "Soloist",
-  "name": "Suho",
-  "group": "EXO",
-  "types": ["Fighting"],
-  "rarity": "Rare Secret",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154778/u2slsu_unordinary_soloist_suho_ndhiun.png"
-},
-{
-  "id": "r2slsu",
-  "cardRarity": "Rare",
-  "cardGroup": "Soloist",
-  "name": "Suho",
-  "group": "EXO",
-  "types": ["Water"],
-  "rarity": "Rare Holo",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154786/r2slsu_rare_soloist_suho_lducu9.png"
-},
-{
-  "id": "s2slsu",
-  "cardRarity": "Special",
-  "cardGroup": "Soloist",
-  "name": "Suho",
-  "group": "EXO",
-  "types": ["Water"],
-  "rarity": "Rare Holo Cosmos",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154794/s2slsu_special_soloist_suho_jhg435.png"
-},
-{
-  "id": "e2slsu",
-  "cardRarity": "Extraordinary",
-  "cardGroup": "Soloist",
-  "name": "Suho",
-  "group": "EXO",
-  "types": ["Psychic"],
-  "rarity": "Radiant Rare",
-  "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154803/e2slsu_extraordinary_soloist_suho_wvcz3x.png"
-}
+  {
+    "id": "gmlchenle",
+    "cardRarity": "Altair",
+    "cardGroup": "Lucky",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901047/gmlchenle_altair_lucky_chenle.png"
+  },
+  {
+    "id": "ftrsmmark",
+    "cardRarity": "Altair",
+    "cardGroup": "Futurism",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Darkness"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901210/ftrsmmark_altair_futurism_mark.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "endjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Darkness"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164391/endjn_extraordinary_nct%20dream_jeno.png"
+  }
 ]

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -16,7 +16,7 @@
 
   // image props
   export let img = "";
-  export let back = "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725179006/card_back_feivelyn.png";
+  export let back = "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729316272/card_back_feivelyn_m2xzjs.png";
   export let foil = "";
   export let mask = "";
 

--- a/src/lib/database/exoLibrary.json
+++ b/src/lib/database/exoLibrary.json
@@ -1687,7 +1687,7 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021980/feseho_priceless_sehun_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321877/feseho_priceless_sehun_suho_o8c7pe.png"
   },
   {
     "id": "roycdo",
@@ -1699,19 +1699,19 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023106/roycdo_priceless_chanyeol_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321129/roycdo_priceless_royal%20event_chanyeol%20do.png"
   },
   {
     "id": "xmkyl",
     "cardRarity": "Priceless",
-    "cardGroup": "Bxmas23",
+    "cardGroup": "Xmas Xmas23 Bxmas23",
     "name": "Kai & Chanyeol",
     "group": "EXO",
     "types": [
       "Grass"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023114/xmkyl_priceless_kai_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320687/xmkyl_priceless_bxmas23_kai%20chanyeol.png"
   },
   {
     "id": "psebh",
@@ -1723,19 +1723,19 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019030/psebh_priceless_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319195/psebh_priceless_stardust_event_baekhyun.png"
   },
   {
     "id": "evbaek",
     "cardRarity": "Priceless",
-    "cardGroup": "Pevil",
+    "cardGroup": "Evil Event Pevil",
     "name": "Baekhyun",
     "group": "EXO",
     "types": [
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019780/evbaek_priceless_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319863/evbaek_priceless_pevil_baekhyun.png"
   },
   {
     "id": "paqbh",
@@ -1759,7 +1759,7 @@
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022646/fmxmbh_priceless_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320605/fmxmbh_priceless_fanmade%20xmas_baekhyun.png"
   },
   {
     "id": "emebae",
@@ -1771,7 +1771,7 @@
       "Grass"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022831/emebae_priceless_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319687/emebae_priceless_emerald_baekhyun.png"
   },
   {
     "id": "tyubae",
@@ -1783,7 +1783,7 @@
       "Psychic"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022840/tyubae_priceless_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320445/tyubae_priceless_thanku_baekhyun.png"
   },
   {
     "id": "sapchn",
@@ -1793,7 +1793,7 @@
     "group": "EXO",
     "types": [""],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1727630926/sapchn_priceless_sapphire_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321069/sapchn_priceless_sapphire_chen_zqmsio.png"
   },
   {
     "id": "psecn",
@@ -1805,19 +1805,19 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019092/psecn_priceless_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319218/psecn_priceless_stardust_event_chen.png"
   },
   {
     "id": "evchen",
     "cardRarity": "Priceless",
-    "cardGroup": "Bevil",
+    "cardGroup": "Evil Event Bevil",
     "name": "Chen",
     "group": "EXO",
     "types": [
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019548/evchen_priceless_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319883/evchen_priceless_bevil_chen.png"
   },
   {
     "id": "virche",
@@ -1829,19 +1829,19 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022845/virche_priceless_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320944/virche_priceless_virgo_chen.png"
   },
   {
     "id": "faeche",
     "cardRarity": "Priceless",
-    "cardGroup": "Pfairies",
+    "cardGroup": "Fairy Fairies Event Pfairies",
     "name": "Chen",
     "group": "EXO",
     "types": [
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022853/faeche_priceless_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321005/faeche_priceless_pfairies_chen.png"
   },
   {
     "id": "psecy",
@@ -1853,19 +1853,19 @@
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725018810/psecy_priceless_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319242/psecy_priceless_stardust%20event_chanyeol.png"
   },
   {
     "id": "evyeol",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil",
+    "cardGroup": "Evil Event",
     "name": "Chanyeol",
     "group": "EXO",
     "types": [
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019411/evyeol_priceless_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319902/evyeol_priceless_evil_chanyeol.png"
   },
   {
     "id": "sagcyl",
@@ -1877,7 +1877,7 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023109/sagcyl_priceless_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321310/sagcyl_priceless_sagittarius_chanyeol.png"
   },
   {
     "id": "srocyl",
@@ -1889,7 +1889,7 @@
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023119/srocyl_priceless_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png"
   },
   {
     "id": "psedo",
@@ -1901,31 +1901,31 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019107/psedo_priceless_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png"
   },
   {
     "id": "evdooo",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil",
+    "cardGroup": "Evil Event",
     "name": "D.O.",
     "group": "EXO",
     "types": [
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019401/evdooo_priceless_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319918/evdooo_priceless_evil_do.png"
   },
   {
     "id": "apodoo",
     "cardRarity": "Priceless",
-    "cardGroup": "Bapocalypse",
+    "cardGroup": "Apocalypse Event Bapocalypse",
     "name": "D.O.",
     "group": "EXO",
     "types": [
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023389/apodoo_priceless_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321437/apodoo_priceless_bapocalypse_do.png"
   },
   {
     "id": "pseka",
@@ -1937,12 +1937,12 @@
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725018903/pseka_priceless_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319330/pseka_priceless_stardust%20event_kai.png"
   },
   {
     "id": "evkaii",
     "cardRarity": "Priceless",
-    "cardGroup": "Pevil",
+    "cardGroup": "Evil Event Pevil",
     "name": "Kai",
     "group": "EXO",
     "types": [
@@ -1954,14 +1954,14 @@
   {
     "id": "xokai",
     "cardRarity": "Priceless",
-    "cardGroup": "PXOXO",
+    "cardGroup": "XOXO Event PXOXO",
     "name": "Kai",
     "group": "EXO",
     "types": [
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023394/xokai_priceless_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321577/xokai_priceless_pxoxo_kai.png"
   },
   {
     "id": "fmxmka",
@@ -1973,19 +1973,19 @@
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023398/fmxmka_priceless_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320792/fmxmka_priceless_fanmade%20xmas_kai.png"
   },
   {
     "id": "sfmatt",
     "cardRarity": "Priceless",
-    "cardGroup": "Staffmate",
+    "cardGroup": "Staffmate Event",
     "name": "Kai",
     "group": "EXO",
     "types": [
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023718/sfmatt_priceless_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321650/sfmatt_priceless_staffmate_kai.png"
   },
   {
     "id": "psela",
@@ -1997,19 +1997,19 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978346/psela_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319384/psela_priceless_stardust%20event_lay.png"
   },
   {
     "id": "evlayy",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil",
+    "cardGroup": "Evil Event",
     "name": "Lay",
     "group": "EXO",
     "types": [
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019320/evlayy_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320043/evlayy_priceless_evil_lay.png"
   },
   {
     "id": "roylay",
@@ -2017,11 +2017,9 @@
     "cardGroup": "Royal Event",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022389/roylay_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729332347/roylay_priceless_royal%20event_lay.png"
   },
   {
     "id": "liblay",
@@ -2033,43 +2031,43 @@
       "Psychic"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022393/liblay_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321774/liblay_priceless_libra_lay.png"
   },
   {
     "id": "xmlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Xmas23",
+    "cardGroup": "Xmas Xmas23",
     "name": "Lay",
     "group": "EXO",
     "types": [
       "Grass"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022400/xmlay_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320813/xmlay_priceless_xmas23_lay.png"
   },
   {
     "id": "slmlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Psoulmate",
+    "cardGroup": "Soulmate Event Psoulmate",
     "name": "Lay",
     "group": "EXO",
     "types": [
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022622/slmlay_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321821/slmlay_priceless_psoulmate_lay.png"
   },
   {
     "id": "sumlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Bsummer",
+    "cardGroup": "Summer Event Bsummer",
     "name": "Lay",
     "group": "EXO",
     "types": [
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022641/sumlay_priceless_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321719/sumlay_priceless_bsummer_lay.png"
   },
   {
     "id": "psesh",
@@ -2081,31 +2079,31 @@
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725018680/psesh_priceless_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319399/psesh_priceless_stardust%20event_sehun.png"
   },
   {
     "id": "evehun",
     "cardRarity": "Priceless",
-    "cardGroup": "Bevil",
+    "cardGroup": "Evil Event Bevil",
     "name": "Sehun",
     "group": "EXO",
     "types": [
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019558/evehun_priceless_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320068/evehun_priceless_bevil_sehun.png"
   },
   {
     "id": "cdyshn",
     "cardRarity": "Priceless",
-    "cardGroup": "Candy",
+    "cardGroup": "Candy Event",
     "name": "Sehun",
     "group": "EXO",
     "types": [
       "Psychic"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978242/cdyshn_priceless_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321982/cdyshn_priceless_candy_sehun.png"
   },
   {
     "id": "diaseh",
@@ -2117,7 +2115,7 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725023429/diaseh_priceless_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321927/diaseh_priceless_diamond_sehun.png"
   },
   {
     "id": "psesu",
@@ -2129,31 +2127,31 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978032/psesu_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319419/psesu_priceless_stardust%20event_suho.png"
   },
   {
     "id": "evsuho",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil",
+    "cardGroup": "Evil Event",
     "name": "Suho",
     "group": "EXO",
     "types": [
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019538/evsuho_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320077/evsuho_priceless_evil_suho.png"
   },
   {
     "id": "aposuh",
     "cardRarity": "Priceless",
-    "cardGroup": "Apocalypse",
+    "cardGroup": "Apocalypse Event",
     "name": "Suho",
     "group": "EXO",
     "types": [
       "Metal"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021983/aposuh_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321448/aposuh_priceless_apocalypse_suho.png"
   },
   {
     "id": "emesuh",
@@ -2165,19 +2163,19 @@
       "Green"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021991/emesuh_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319703/emesuh_priceless_emerald_suho.png"
   },
   {
     "id": "btasuh",
     "cardRarity": "Priceless",
-    "cardGroup": "BTA",
+    "cardGroup": "BTA Event",
     "name": "Suho",
     "group": "EXO",
     "types": [
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022002/btasuh_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322246/btasuh_priceless_bta_suho.png"
   },
   {
     "id": "1KSUHO",
@@ -2189,7 +2187,7 @@
       "Fire"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022197/1KSUHO_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322055/1KSUHO_priceless_1k%20special_suho.png"
   },
   {
     "id": "2KSUHO",
@@ -2201,7 +2199,7 @@
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022202/2KSUHO_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322069/2KSUHO_priceless_2k%20special_suho.png"
   },
   {
     "id": "3KSUHO",
@@ -2213,19 +2211,19 @@
       "Water"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022209/3KSUHO_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322125/3KSUHO_priceless_3k%20special_suho.png"
   },
   {
     "id": "hbdasaki",
     "cardRarity": "Priceless",
-    "cardGroup": "Staff Birthday",
+    "cardGroup": "Staff Birthday Event",
     "name": "Suho",
     "group": "EXO",
     "types": [
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725022383/hbdasaki_priceless_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322184/hbdasaki_priceless_staff%20birthday_suho.png"
   },
   {
     "id": "psexm",
@@ -2237,7 +2235,7 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019227/psexm_priceless_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319427/psexm_priceless_stardust%20event_xiumin.png"
   },
   {
     "id": "zuhxmn",
@@ -2249,7 +2247,7 @@
       "Water"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021690/zuhxmn_priceless_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322783/zuhxmn_priceless_cardcaptor_xiumin.png"
   },
   {
     "id": "aquxiu",
@@ -2261,19 +2259,19 @@
       "Grass"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021759/aquxiu_priceless_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322669/aquxiu_priceless_aquamarine_xiumin.png"
   },
   {
     "id": "apfxiu",
     "cardRarity": "Priceless",
-    "cardGroup": "Bapf",
+    "cardGroup": "April Fools Event Bapf",
     "name": "Xiumin",
     "group": "EXO",
     "types": [
       "Fairy"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021763/apfxiu_priceless_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322721/apfxiu_priceless_bapf_xiumin.png"
   },
   {
     "id": "anexbh",
@@ -2285,7 +2283,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020920/anexbh_altair_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318712/anexbh_altair_anniversary_baekhyun.png"
   },
   {
     "id": "12yrsbh",
@@ -2297,7 +2295,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021323/12yrsbh_altair_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318265/12yrsbh_altair_anniversary_baekhyun_jgbzmo.png"
   },
   {
     "id": "anexch",
@@ -2309,7 +2307,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978425/anexch_altair_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318750/anexch_altair_anniversary_chen.png"
   },
   {
     "id": "12yrsch",
@@ -2321,7 +2319,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021417/12yrsch_altair_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318290/12yrsch_altair_anniversary_chen_qecx1x.png"
   },
   {
     "id": "anexcy",
@@ -2333,7 +2331,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020940/anexcy_altair_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318796/anexcy_altair_anniversary_chanyeol.png"
   },
   {
     "id": "12yrscy",
@@ -2345,7 +2343,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021429/12yrscy_altair_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318310/12yrscy_altair_anniversary_chanyeol_ybrrev.png"
   },
   {
     "id": "anexdo",
@@ -2357,7 +2355,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021075/anexdo_altair_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318838/anexdo_altair_anniversary_do.png"
   },
   {
     "id": "12yrsdo",
@@ -2369,7 +2367,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021453/12yrsdo_altair_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318327/12yrsdo_altair_anniversary_do.png"
   },
   {
     "id": "anexka",
@@ -2381,7 +2379,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021050/anexka_altair_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318871/anexka_altair_anniversary_kai.png"
   },
   {
     "id": "12yrska",
@@ -2393,7 +2391,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021457/12yrska_altair_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318342/12yrska_altair_anniversary_kai.png"
   },
   {
     "id": "anexla",
@@ -2405,7 +2403,7 @@
       "Psychic"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020659/anexla_altair_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318905/anexla_altair_anniversary_lay.png"
   },
   {
     "id": "12yrsla",
@@ -2417,7 +2415,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021318/12yrsla_altair_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318364/12yrsla_altair_anniversary_lay.png"
   },
   {
     "id": "anexsh",
@@ -2429,7 +2427,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021059/anexsh_altair_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318959/anexsh_altair_anniversary_sehun.png"
   },
   {
     "id": "12yrssh",
@@ -2441,7 +2439,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021584/12yrssh_altair_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318380/12yrssh_altair_anniversary_sehun.png"
   },
   {
     "id": "anexsu",
@@ -2453,7 +2451,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020645/anexsu_altair_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318995/anexsu_altair_anniversary_suho.png"
   },
   {
     "id": "12yrssu",
@@ -2465,7 +2463,7 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725021304/12yrssu_altair_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318395/12yrssu_altair_anniversary_suho.png"
   },
   {
     "id": "bunsuho",
@@ -2477,7 +2475,7 @@
       "Fairy"
     ],
     "rarity": "Amazing Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020024/bunsuho_altair_suho.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322333/bunsuho_altair_fanmade%20special_suho.png",
     "mask": "",
     "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
   },
@@ -2492,7 +2490,7 @@
     ],
     "rarity": "Rare Holo VMAX",
     "isTrainer": "true",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020010/castlesuho_altair_suho.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322358/castlesuho_altair_fanmade%20special_suho.png",
     "mask": "",
     "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png"
   },
@@ -2506,7 +2504,7 @@
       "Water"
     ],
     "rarity": "Amazing Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020478/minisuho_altair_suho.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322374/minisuho_altair_fanmade%20special_suho.png",
     "mask": "",
     "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
   },
@@ -2514,13 +2512,13 @@
     "id": "p0rtr4it",
     "cardRarity": "Altair",
     "cardGroup": "Fanmade Special",
-    "name": "Suho",
+    "name": "Suho portrait",
     "group": "EXO",
     "types": [
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019893/p0rtr4it_altair_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322571/p0rtr4it_altair_fanmade%20special_suho.png"
   },
   {
     "id": "starsuho",
@@ -2532,7 +2530,7 @@
       "Psychic"
     ],
     "rarity": "Amazing Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724999594/starsuho_altair_suho.png",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322390/starsuho_altair_starry%20night_suho.png",
     "mask": "",
     "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png"
   },
@@ -2546,7 +2544,7 @@
       "Fairy"
     ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725020625/anexxm_altair_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319010/anexxm_altair_anniversary_xiumin.png"
   },
   {
     "id": "12yrsxm",
@@ -2558,12 +2556,12 @@
       "Metal"
     ],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724978506/12yrsxm_altair_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318409/12yrsxm_altair_anniversary_xiumin.png"
   },
   {
     "id": "ocbbh",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Baekhyun",
     "group": "EXO",
     "types": ["Fire"],
@@ -2573,7 +2571,7 @@
   {
     "id": "ocbcn",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Chen",
     "group": "EXO",
     "types": ["Grass"],
@@ -2583,7 +2581,7 @@
   {
     "id": "ocbxm",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Xiumin",
     "group": "EXO",
     "types": ["Fairy"],
@@ -2593,7 +2591,7 @@
   {
     "id": "ucbbh",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Baekhyun",
     "group": "EXO",
     "types": ["Fairy"],
@@ -2603,7 +2601,7 @@
   {
     "id": "ucbcn",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Chen",
     "group": "EXO",
     "types": ["Fairy"],
@@ -2613,7 +2611,7 @@
   {
     "id": "ucbxm",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX",
+    "cardGroup": "EXO-CBX CBX",
     "name": "Xiumin",
     "group": "EXO",
     "types": ["Water"],
@@ -2739,105 +2737,5 @@
     ],
     "rarity": "Radiant Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158788/eessh_extraordinary_sc_sehun_tbdhjs.png"
-  },
-  {
-    "id": "osmbh",
-    "cardRarity": "Ordinary",
-    "cardGroup": "SuperM",
-    "name": "Baekhyun",
-    "group": "EXO",
-    "types": ["Metal"],
-    "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160135/osmbh_ordinary_superm_baekhyun_ajmxbe.png"
-  },
-  {
-    "id": "osmka",
-    "cardRarity": "Ordinary",
-    "cardGroup": "SuperM",
-    "name": "Kai",
-    "group": "EXO",
-    "types": ["Metal"],
-    "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160138/osmka_ordinary_superm_kai_df3fw4.png"
-  },
-  {
-    "id": "usmbh",
-    "cardRarity": "Unordinary",
-    "cardGroup": "SuperM",
-    "name": "Baekhyun",
-    "group": "EXO",
-    "types": ["Water"],
-    "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160143/usmbh_unordinary_superm_baekhyun_v1n2aq.png"
-  },
-  {
-    "id": "usmka",
-    "cardRarity": "Unordinary",
-    "cardGroup": "SuperM",
-    "name": "Kai",
-    "group": "EXO",
-    "types": ["Metal"],
-    "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160147/usmka_unordinary_superm_kai_gbpmfl.png"
-  },
-  {
-    "id": "rsmbh",
-    "cardRarity": "Rare",
-    "cardGroup": "SuperM",
-    "name": "Baekhyun",
-    "group": "EXO",
-    "types": ["Water"],
-    "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160227/rsmbh_rare_superm_baekhyun_s70oyp.png"
-  },
-  {
-    "id": "rsmka",
-    "cardRarity": "Rare",
-    "cardGroup": "SuperM",
-    "name": "Kai",
-    "group": "EXO",
-    "types": ["Fighting"],
-    "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160231/rsmka_rare_superm_kai_fhkz0x.png"
-  },
-  {
-    "id": "ssmbh",
-    "cardRarity": "Special",
-    "cardGroup": "SuperM",
-    "name": "Baekhyun",
-    "group": "EXO",
-    "types": ["Lightning"],
-    "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160236/ssmbh_special_superm_baekhyun_k08vak.png"
-  },
-  {
-    "id": "ssmka",
-    "cardRarity": "Special",
-    "cardGroup": "SuperM",
-    "name": "Kai",
-    "group": "EXO",
-    "types": ["Lightning"],
-    "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160239/ssmka_special_superm_kai_yg3ctm.png"
-  },
-  {
-    "id": "esmbh",
-    "cardRarity": "Extraordinary",
-    "cardGroup": "SuperM",
-    "name": "Baekhyun",
-    "group": "EXO",
-    "types": ["Metal"],
-    "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160244/esmbh_extraordinary_superm_baekhyun_fusbmj.png"
-  },
-  {
-    "id": "esmka",
-    "cardRarity": "Extraordinary",
-    "cardGroup": "SuperM",
-    "name": "Kai",
-    "group": "EXO",
-    "types": ["Fighting"],
-    "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160247/esmka_extraordinary_superm_kai_esgs4w.png"
   }
 ]

--- a/src/lib/database/nctLibrary.json
+++ b/src/lib/database/nctLibrary.json
@@ -1,0 +1,2176 @@
+[
+  {
+    "id": "oncdy",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/oncdy_ordinary_nct127_doyoung.png"
+  },
+  {
+    "id": "onchc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215794/onchc_ordinary_nct127_haechan.png"
+  },
+  {
+    "id": "oncjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215826/oncjh_ordinary_nct127_jaehyun.png"
+  },
+  {
+    "id": "oncjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215797/oncjn_ordinary_nct127_johnny.png"
+  },
+  {
+    "id": "oncjw",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215801/oncjw_ordinary_nct127_jungwoo.png"
+  },
+  {
+    "id": "oncmk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215803/oncmk_ordinary_nct127_mark.png"
+  },
+  {
+    "id": "oncty",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215806/oncty_ordinary_nct127_taeyong.png"
+  },
+  {
+    "id": "oncyt",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/oncyt_ordinary_nct127_yuta.png"
+  },
+  {
+    "id": "uncdy",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Water"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215841/uncdy_unordinary_nct127_doyoung.png"
+  },
+  {
+    "id": "unchc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215846/unchc_unordinary_nct127_haechan.png"
+  },
+  {
+    "id": "uncjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/uncjh_unordinary_nct127_jaehyun.png"
+  },
+  {
+    "id": "uncjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215758/uncjn_unordinary_nct127_johnny.png"
+  },
+  {
+    "id": "uncjw",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215753/uncjw_unordinary_nct127_jungwoo.png"
+  },
+  {
+    "id": "uncmk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215778/uncmk_unordinary_nct127_mark.png"
+  },
+  {
+    "id": "uncty",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/uncty_unordinary_nct127_taeyong.png"
+  },
+  {
+    "id": "uncyt",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215765/uncyt_unordinary_nct127_yuta.png"
+  },
+  {
+    "id": "rncdy",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Dragon"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215813/rncdy_rare_nct127_doyoung.png"
+  },
+  {
+    "id": "rnchc",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215832/rnchc_rare_nct127_haechan.png"
+  },
+  {
+    "id": "rncjh",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215818/rncjh_rare_nct127_jaehyun.png"
+  },
+  {
+    "id": "rncjn",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/rncjn_rare_nct127_johnny.png"
+  },
+  {
+    "id": "rncjw",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215840/rncjw_rare_nct127_jungwoo.png"
+  },
+  {
+    "id": "rncmk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Water"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/rncmk_rare_nct127_mark.png"
+  },
+  {
+    "id": "rncty",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215843/rncty_rare_nct127_taeyong.png"
+  },
+  {
+    "id": "rncyt",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT127 127",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215842/rncyt_rare_nct127_yuta.png"
+  },
+  {
+    "id": "sncdy",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215773/sncdy_special_nct127_doyoung.png"
+  },
+  {
+    "id": "snchc",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215766/snchc_special_nct127_haechan.png"
+  },
+  {
+    "id": "sncjh",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215751/sncjh_special_nct127_jaehyun.png"
+  },
+  {
+    "id": "sncjn",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215777/sncjn_special_nct127_johnny.png"
+  },
+  {
+    "id": "sncjw",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215769/sncjw_special_nct127_jungwoo.png"
+  },
+  {
+    "id": "sncmk",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215762/sncmk_special_nct127_mark.png"
+  },
+  {
+    "id": "sncty",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215759/sncty_special_nct127_taeyong.png"
+  },
+  {
+    "id": "sncyt",
+    "cardRarity": "Special",
+    "cardGroup": "NCT127 127",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/sncyt_special_nct127_yuta.png"
+  },
+  {
+    "id": "encdy",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/encdy_extraordinary_nct127_doyoung.png"
+  },
+  {
+    "id": "enchc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215772/enchc_extraordinary_nct127_haechan.png"
+  },
+  {
+    "id": "encjh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/encjh_extraordinary_nct127_jaehyun.png"
+  },
+  {
+    "id": "encjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215779/encjn_extraordinary_nct127_johnny.png"
+  },
+  {
+    "id": "encjw",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215820/encjw_extraordinary_nct127_jungwoo.png"
+  },
+  {
+    "id": "encmk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/encmk_extraordinary_nct127_mark.png"
+  },
+  {
+    "id": "encty",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215783/encty_extraordinary_nct127_taeyong.png"
+  },
+  {
+    "id": "encyt",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT127 127",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215788/encyt_extraordinary_nct127_yuta.png"
+  },
+  {
+    "id": "ondch",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/ondch_ordinary_nct%20dream_chenle.png"
+  },
+  {
+    "id": "ondhc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Water"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164311/ondhc_ordinary_nct%20dream_haechan.png"
+  },
+  {
+    "id": "ondjm",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Psychic"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjm_ordinary_nct%20dream_jaemin.png"
+  },
+  {
+    "id": "ondjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjn_ordinary_nct%20dream_jeno.png"
+  },
+  {
+    "id": "ondjs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164318/ondjs_ordinary_nct%20dream_jisung.png"
+  },
+  {
+    "id": "ondmk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Darkness"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164326/ondmk_ordinary_nct%20dream_mark.png"
+  },
+  {
+    "id": "ondrj",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Dragon"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164325/ondrj_ordinary_nct%20dream_renjun.png"
+  },
+  {
+    "id": "undch",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undch_unordinary_nct%20dream_chenle.png"
+  },
+  {
+    "id": "undhc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undhc_unordinary_nct%20dream_haechan.png"
+  },
+  {
+    "id": "undjm",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164354/undjm_unordinary_nct%20dream_jaemin.png"
+  },
+  {
+    "id": "undjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjn_unordinary_nct%20dream_jeno.png"
+  },
+  {
+    "id": "undjs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjs_unordinary_nct%20dream_jisung.png"
+  },
+  {
+    "id": "undmk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164360/undmk_unordinary_nct%20dream_mark.png"
+  },
+  {
+    "id": "undrj",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164374/undrj_unordinary_nct%20dream_renjun.png"
+  },
+  {
+    "id": "rndch",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164327/rndch_rare_nct%20dream_chenle.png"
+  },
+  {
+    "id": "rndhc",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164341/rndhc_rare_nct%20dream_haechan.png"
+  },
+  {
+    "id": "rndjm",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164344/rndjm_rare_nct%20dream_jaemin.png"
+  },
+  {
+    "id": "rndjn",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164345/rndjn_rare_nct%20dream_jeno.png"
+  },
+  {
+    "id": "rndjs",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164348/rndjs_rare_nct%20dream_jisung.png"
+  },
+  {
+    "id": "rndmk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/rndmk_rare_nct%20dream_mark.png"
+  },
+  {
+    "id": "rndrj",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT Dream",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Fighting"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164320/rndrj_rare_nct%20dream_renjun.png"
+  },
+  {
+    "id": "sndch",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndch_special_nct%20dream_chenle.png"
+  },
+  {
+    "id": "sndhc",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164387/sndhc_special_nct%20dream_haechan.png"
+  },
+  {
+    "id": "sndjm",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164389/sndjm_special_nct%20dream_jaemin.png"
+  },
+  {
+    "id": "sndjn",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndjn_special_nct%20dream_jeno.png"
+  },
+  {
+    "id": "sndjs",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndjs_special_nct%20dream_jisung.png"
+  },
+  {
+    "id": "sndmk",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndmk_special_nct%20dream_mark.png"
+  },
+  {
+    "id": "sndrj",
+    "cardRarity": "Special",
+    "cardGroup": "NCT Dream",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/sndrj_special_nct%20dream_renjun.png"
+  },
+  {
+    "id": "endch",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fighting"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164367/endch_extraordinary_nct%20dream_chenle.png"
+  },
+  {
+    "id": "endhc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164371/endhc_extraordinary_nct%20dream_haechan.png"
+  },
+  {
+    "id": "endjm",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164329/endjm_extraordinary_nct%20dream_jaemin.png"
+  },
+  {
+    "id": "endjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Darkness"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164391/endjn_extraordinary_nct%20dream_jeno.png"
+  },
+  {
+    "id": "endjs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164381/endjs_extraordinary_nct%20dream_jisung.png"
+  },
+  {
+    "id": "endmk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164377/endmk_extraordinary_nct%20dream_mark.png"
+  },
+  {
+    "id": "endrj",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "NCT Dream",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164376/endrj_extraordinary_nct%20dream_renjun.png"
+  },
+  {
+    "id": "owvhd",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980665/owvhd_ordinary_wayv_hendery.png"
+  },
+  {
+    "id": "owvkn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvkn_ordinary_wayv_kun.png"
+  },
+  {
+    "id": "owvtn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvtn_ordinary_wayv_ten.png"
+  },
+  {
+    "id": "owvww",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980634/owvww_ordinary_wayv_winwin.png"
+  },
+  {
+    "id": "owvxj",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980638/owvxj_ordinary_wayv_xiaojun.png"
+  },
+  {
+    "id": "owvyy",
+    "cardRarity": "Ordinary",
+    "cardGroup": "WayV",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980637/owvyy_ordinary_wayv_yangyang.png"
+  },
+  {
+    "id": "uwvhd",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/uwvhd_unordinary_wayv_hendery.png"
+  },
+  {
+    "id": "uwvkn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980669/uwvkn_unordinary_wayv_kun.png"
+  },
+  {
+    "id": "uwvtn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980671/uwvtn_unordinary_wayv_ten.png"
+  },
+  {
+    "id": "uwvww",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980675/uwvww_unordinary_wayv_winwin.png"
+  },
+  {
+    "id": "uwvxj",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980658/uwvxj_unordinary_wayv_xiaojun.png"
+  },
+  {
+    "id": "uwvyy",
+    "cardRarity": "Unordinary",
+    "cardGroup": "WayV",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/uwvyy_unordinary_wayv_yangyang.png"
+  },
+  {
+    "id": "rwvhd",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvhd_rare_wayv_hendery.png"
+  },
+  {
+    "id": "rwvkn",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvkn_rare_wayv_kun.png"
+  },
+  {
+    "id": "rwvtn",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980644/rwvtn_rare_wayv_ten.png"
+  },
+  {
+    "id": "rwvww",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/rwvww_rare_wayv_winwin.png"
+  },
+  {
+    "id": "rwvxj",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvxj_rare_wayv_xiaojun.png"
+  },
+  {
+    "id": "rwvyy",
+    "cardRarity": "Rare",
+    "cardGroup": "WayV",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980647/rwvyy_rare_wayv_yangyang.png"
+  },
+  {
+    "id": "swvhd",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvhd_special_wayv_hendery.png"
+  },
+  {
+    "id": "swvkn",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980674/swvkn_special_wayv_kun.png"
+  },
+  {
+    "id": "swvtn",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvtn_special_wayv_ten.png"
+  },
+  {
+    "id": "swvww",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980653/swvww_special_wayv_winwin.png"
+  },
+  {
+    "id": "swvxj",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvxj_special_wayv_xiaojun.png"
+  },
+  {
+    "id": "swvyy",
+    "cardRarity": "Special",
+    "cardGroup": "WayV",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvyy_special_wayv_yangyang.png"
+  },
+  {
+    "id": "ewvhd",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980656/ewvhd_extraordinary_wayv_hendery.png"
+  },
+  {
+    "id": "ewvkn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980645/ewvkn_extraordinary_wayv_kun.png"
+  },
+  {
+    "id": "ewvtn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980661/ewvtn_extraordinary_wayv_ten.png"
+  },
+  {
+    "id": "ewvww",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980646/ewvww_extraordinary_wayv_winwin.png"
+  },
+  {
+    "id": "ewvxj",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/ewvxj_extraordinary_wayv_xiaojun.png"
+  },
+  {
+    "id": "ewvyy",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "WayV",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/ewvyy_extraordinary_wayv_yangyang.png"
+  },
+  {
+    "id": "ukxkn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "KUN&XIAOJUN",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Water"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984903/ukxkn_ordinary_kun-xiaojun_kun.png"
+  },
+  {
+    "id": "okxkn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "KUN&XIAOJUN",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984892/okxkn_ordinary_kun-xiaojun_kun.png"
+  },
+  {
+    "id": "ukxxj",
+    "cardRarity": "Ordinary",
+    "cardGroup": "KUN&XIAOJUN",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Water"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984909/ukxxj_ordinary_kun-xiaojun_xiaojun.png"
+  },
+  {
+    "id": "okxxj",
+    "cardRarity": "Ordinary",
+    "cardGroup": "KUN&XIAOJUN",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984896/okxxj_ordinary_kun-xiaojun_xiaojun.png"
+  },
+  {
+    "id": "osljh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221939/osljh_ordinary_soloist_jaehyun.png"
+  },
+  {
+    "id": "oslmk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221955/oslmk_ordinary_soloist_mark.png"
+  },
+  {
+    "id": "oslty",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221751/oslty_ordinary_soloist_taeyong.png"
+  },
+  {
+    "id": "osltn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Dragon"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221968/osltn_ordinary_soloist_ten.png"
+  },
+  {
+    "id": "usljh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222076/usljh_unordinary_soloist_jaehyun.png"
+  },
+  {
+    "id": "uslmk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222098/uslmk_unordinary_soloist_mark.png"
+  },
+  {
+    "id": "uslty",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221884/uslty_unordinary_soloist_taeyong.png"
+  },
+  {
+    "id": "usltn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Grass"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221748/usltn_unordinary_soloist_ten.png"
+  },
+  {
+    "id": "rsljh",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221981/rsljh_rare_soloist_jaehyun.png"
+  },
+  {
+    "id": "rslmk",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Water"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221999/rslmk_rare_soloist_mark.png"
+  },
+  {
+    "id": "rslty",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221867/rslty_rare_soloist_taeyong.png"
+  },
+  {
+    "id": "rsltn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222016/rsltn_rare_soloist_ten.png"
+  },
+  {
+    "id": "ssljh",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222034/ssljh_special_soloist_jaehyun.png"
+  },
+  {
+    "id": "sslmk",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222048/sslmk_special_soloist_mark.png"
+  },
+  {
+    "id": "sslty",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221877/sslty_special_soloist_taeyong.png"
+  },
+  {
+    "id": "ssltn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222062/ssltn_special_soloist_ten.png"
+  },
+  {
+    "id": "esljh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221893/esljh_extraordinary_soloist_jaehyun.png"
+  },
+  {
+    "id": "eslmk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221904/eslmk_extraordinary_soloist_mark.png"
+  },
+  {
+    "id": "eslty",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221925/eslty_extraordinary_soloist_taeyong.png"
+  },
+  {
+    "id": "esltn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Ten WayV",
+    "group": "NCT",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221915/esltn_extraordinary_soloist_ten.png"
+  },
+  {
+    "id": "sfmyve",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate Event",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/sfmyve_priceless_staffmate_yuta.png"
+  },
+  {
+    "id": "scoyut",
+    "cardRarity": "Priceless",
+    "cardGroup": "Scorpio",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/scoyut_priceless_scorpio_yuta.png"
+  },
+  {
+    "id": "amejae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/amejae_priceless_amethyst_jaehyun.png"
+  },
+  {
+    "id": "ubyong",
+    "cardRarity": "Priceless",
+    "cardGroup": "Ruby",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/ubyong_priceless_ruby_taeyong.png"
+  },
+  {
+    "id": "sarryo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "Ryo",
+    "group": "NCT WISH",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990218/sarryo_priceless_sardonyx_ryo.png"
+  },
+  {
+    "id": "emesio",
+    "cardRarity": "Priceless",
+    "cardGroup": "Emerald",
+    "name": "Sion",
+    "group": "NCT WISH",
+    "types": ["Grass"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990213/emesio_priceless_emerald_sion.png"
+  },
+  {
+    "id": "slmjae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Soulmate Event",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990212/slmjae_priceless_soulmate_jaehyun.png"
+  },
+  {
+    "id": "libion",
+    "cardRarity": "Priceless",
+    "cardGroup": "Libra",
+    "name": "Sion",
+    "group": "NCT WISH",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/libion_priceless_libra_sion.png"
+  },
+  {
+    "id": "cantae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Cancer",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/cantae_priceless_cancer_taeyong.png"
+  },
+  {
+    "id": "btaiku",
+    "cardRarity": "Priceless",
+    "cardGroup": "BTA",
+    "name": "Riku",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/btaiku_priceless_bta_riku.png"
+  },
+  {
+    "id": "apodoy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Apocalypse Event",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/apodoy_priceless_apocalypse_doyoung.png"
+  },
+  {
+    "id": "apfjoh",
+    "cardRarity": "Priceless",
+    "cardGroup": "April Fools Event Apf",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/apfjoh_priceless_apf_johnny.png"
+  },
+  {
+    "id": "amedoy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/amedoy_priceless_amethyst_doyoung.png"
+  },
+  {
+    "id": "apfdoy",
+    "cardRarity": "Priceless",
+    "cardGroup": "April Fools Event Bapf",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/apfdoy_priceless_apd_doyoung.png"
+  },
+  {
+    "id": "amejoh",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/amejoh_priceless_amethyst_johnny.png"
+  },
+  {
+    "id": "amewoo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990200/amewoo_priceless_amethyst_jungwoo.png"
+  },
+  {
+    "id": "alejae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Jaehee",
+    "group": "NCT WISH",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/alejae_priceless_alexandrite_jaehee.png"
+  },
+  {
+    "id": "sumren",
+    "cardRarity": "Priceless",
+    "cardGroup": "Summer Event",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/sumren_priceless_summer_renjun.png"
+  },
+  {
+    "id": "xm127",
+    "cardRarity": "Priceless",
+    "cardGroup": "Xmas Xmas23",
+    "name": "NCT127 127 group",
+    "group": "NCT NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/xm127_priceless_xmas23_nct_127.png"
+  },
+  {
+    "id": "sroark",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sanrio",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/sroark_priceless_sanrio_mark.png"
+  },
+  {
+    "id": "roykun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Royal Event",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/roykun_priceless_royal%20event_kun.png"
+  },
+  {
+    "id": "sfmwni",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate Event",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/sfmwni_priceless_staffmate_renjun.png"
+  },
+  {
+    "id": "sarark",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990187/sarark_priceless_sardonyx_mark.png"
+  },
+  {
+    "id": "leomar",
+    "cardRarity": "Priceless",
+    "cardGroup": "Leo",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/leomar_priceless_leo_mark.png"
+  },
+  {
+    "id": "sarjae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/sarjae_priceless_sardonyx_jaemin.png"
+  },
+  {
+    "id": "leomin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Leo",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Dragon"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990182/leomin_priceless_leo_jaemin.png"
+  },
+  {
+    "id": "zuhjno",
+    "cardRarity": "Priceless",
+    "cardGroup": "Cardcaptor",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990181/zuhjno_priceless_cardcaptor_jeno.png"
+  },
+  {
+    "id": "sagche",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sagittarius",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990178/sagche_priceless_sagittarius_chenle.png"
+  },
+  {
+    "id": "pseyt",
+    "cardRarity": "Priceless",
+    "cardGroup": "Stardust Event",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990177/pseyt_priceless_stardust_event_yuta.png"
+  },
+  {
+    "id": "hbdrhi",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Darkness"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990176/hbdrhi_priceless_staff%20birthday_jisung.png"
+  },
+  {
+    "id": "fmxmcl",
+    "cardRarity": "Priceless",
+    "cardGroup": "Fanmade Xmas",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Lightning"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990172/fmxmcl_priceless_fanmade%20xmas_chenle.png"
+  },
+  {
+    "id": "evhaec",
+    "cardRarity": "Priceless",
+    "cardGroup": "Evil Event",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/evhaec_priceless_evil_haechan.gif"
+  },
+  {
+    "id": "faejsg",
+    "cardRarity": "Priceless",
+    "cardGroup": "Fairy Fairies Event",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990170/faejsg_priceless_fairies_jisung.png"
+  },
+  {
+    "id": "diajen",
+    "cardRarity": "Priceless",
+    "cardGroup": "Diamond",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/diajen_priceless_diamond_jeno.png"
+  },
+  {
+    "id": "btahae",
+    "cardRarity": "Priceless",
+    "cardGroup": "BTA",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990168/btahae_priceless_bta_haechan.png"
+  },
+  {
+    "id": "cdycnl",
+    "cardRarity": "Priceless",
+    "cardGroup": "Candy Event",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990166/cdycnl_priceless_candy_chenle.png"
+  },
+  {
+    "id": "amejis",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990163/amejis_priceless_amethyst_jisung.png"
+  },
+  {
+    "id": "alehae",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990162/alehae_priceless_alexandrite_haechan.png"
+  },
+  {
+    "id": "apfjmn",
+    "cardRarity": "Priceless",
+    "cardGroup": "April Fools Event Papf",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/apfjmn_priceless_apf_jaemin.png"
+  },
+  {
+    "id": "xowin",
+    "cardRarity": "Priceless",
+    "cardGroup": "XOXO Event",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/xowin_priceless_xoxo_winwin.png"
+  },
+  {
+    "id": "tyuten",
+    "cardRarity": "Priceless",
+    "cardGroup": "Thanku",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990158/tyuten_priceless_thanku_ten.png"
+  },
+  {
+    "id": "sumwin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Summer",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990153/sumwin_priceless_summer_winwin.png"
+  },
+  {
+    "id": "sarjun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sarjun_priceless_sardonyx_xiaojun.png"
+  },
+  {
+    "id": "sapder",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sapphire",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sapder_priceless_sapphire_hendery.png"
+  },
+  {
+    "id": "sroery",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sanrio",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990151/sroery_priceless_sanrio_hendery.png"
+  },
+  {
+    "id": "scowin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Scorpio",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990149/scowin_priceless_scorpio_winwin.png"
+  },
+  {
+    "id": "pserj",
+    "cardRarity": "Priceless",
+    "cardGroup": "Stardust Event",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990147/pserj_priceless_stardust%20event_renjun.png"
+  },
+  {
+    "id": "paqxj",
+    "cardRarity": "Priceless",
+    "cardGroup": "Aphrodite",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990143/paqxj_priceless_aphrodite_xiaojun.png"
+  },
+  {
+    "id": "leojun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Leo",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Dragon"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990141/leojun_priceless_leo_xiaojun.png"
+  },
+  {
+    "id": "evtenn",
+    "cardRarity": "Priceless",
+    "cardGroup": "Evil Event",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Grass"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/evtenn_priceless_evil_ten.png"
+  },
+  {
+    "id": "libhen",
+    "cardRarity": "Priceless",
+    "cardGroup": "Libra",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/libhen_priceless_libra_hendery.png"
+  },
+  {
+    "id": "apokun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Apocalypse Event",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990137/apokun_priceless_apocalypse_kun.png"
+  },
+  {
+    "id": "faexia",
+    "cardRarity": "Priceless",
+    "cardGroup": "Fairy Fairies Event",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990133/faexia_priceless_fairies_xiaojun.png"
+  },
+  {
+    "id": "apften",
+    "cardRarity": "Priceless",
+    "cardGroup": "April Fools Event Papf",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": "",
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/apften_priceless_apf_ten.png"
+  },
+  {
+    "id": "ameten",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/ameten_priceless_amethyst_ten.png"
+  },
+  {
+    "id": "roydoy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Royal Event",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Dragon"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990127/roydoy_priceless_royal%20event_doyoung.png"
+  },
+  {
+    "id": "hbdwonnie",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "NCT Dream group",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/hbdwonnie_priceless_staff%20birthday_nct%20dream.png"
+  },
+  {
+    "id": "xmyyg",
+    "cardRarity": "Priceless",
+    "cardGroup": "Xmas Xmas23",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/xmyyg_priceless_xmas23_yangyang.png"
+  },
+  {
+    "id": "libyyg",
+    "cardRarity": "Priceless",
+    "cardGroup": "Libra",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990124/libyyg_priceless_libra_yangyang.png"
+  },
+  {
+    "id": "aquren",
+    "cardRarity": "Priceless",
+    "cardGroup": "Aquamarine",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990122/aquren_priceless_aquamarine_renjun.png"
+  },
+  {
+    "id": "scosak",
+    "cardRarity": "Priceless",
+    "cardGroup": "Scorpio",
+    "name": "Sakuya",
+    "group": "NCT WISH",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990117/scosak_priceless_scorpio_sakuya.png"
+  },
+  {
+    "id": "anwvww",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985121/anwvww_altair_anniversary_winwin.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anwvtn",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985107/anwvtn_altair_anniversary_ten.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anwvkn",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985093/anwvkn_altair_anniversary_kun.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anwvhd",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Hendery",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985079/anwvhd_altair_anniversary_hendery.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anwvxj",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Xiaojun",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985068/anwvxj_altair_anniversary_xiaojun.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anwvyy",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Yangyang",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985058/anwvyy_altair_anniversary_yangyang.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "anndrj",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Renjun",
+    "group": "NCT Dream",
+    "types": ["Psychic"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260295/anndrj_altair_anniversary_renjun.png"
+  },
+  {
+    "id": "anndmk",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Water"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndmk_altair_anniversary_mark.png"
+  },
+  {
+    "id": "anndjn",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jeno",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260299/anndjn_altair_anniversary_jeno.png"
+  },
+  {
+    "id": "anndhc",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Haechan",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndhc_altair_anniversary_haechan.png"
+  },
+  {
+    "id": "anndjm",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jaemin",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndjm_altair_anniversary_jaemin.png"
+  },
+  {
+    "id": "anndcl",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndcl_altair_anniversary_chenle.png"
+  },
+  {
+    "id": "anndjs",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jisung",
+    "group": "NCT Dream",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903137/anndjs_altair_anniversary_jisung.png"
+  },
+  {
+    "id": "dwjnmk",
+    "cardRarity": "Altair",
+    "cardGroup": "Duoween",
+    "name": "Johnny & Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Fire"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728902100/dwjnmk_altair_duoween_johnny%20mark.png"
+  },
+  {
+    "id": "nwyrkn",
+    "cardRarity": "Altair",
+    "cardGroup": "New Year",
+    "name": "Kun",
+    "group": "NCT WayV",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901655/nwyrkn_altair_new%20year_kun.png"
+  },
+  {
+    "id": "lnywin",
+    "cardRarity": "Altair",
+    "cardGroup": "Lunar Year",
+    "name": "Winwin",
+    "group": "NCT WayV NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901454/lnywin_altair_lunar%20year_winwin.png"
+  },
+  {
+    "id": "ftrsmmark",
+    "cardRarity": "Altair",
+    "cardGroup": "Futurism",
+    "name": "Mark",
+    "group": "NCT Dream NCT127 127",
+    "types": ["Darkness"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901210/ftrsmmark_altair_futurism_mark.png",
+    "mask": "",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+  },
+  {
+    "id": "gmlchenle",
+    "cardRarity": "Altair",
+    "cardGroup": "Lucky",
+    "name": "Chenle",
+    "group": "NCT Dream",
+    "types": ["Grass"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901047/gmlchenle_altair_lucky_chenle.png"
+  },
+  {
+    "id": "foolten",
+    "cardRarity": "Altair",
+    "cardGroup": "Fools",
+    "name": "Ten",
+    "group": "NCT WayV",
+    "types": ["Metal"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900795/foolten_altair_fools_ten_in_wonderland.png"
+  },
+  {
+    "id": "anncjn",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Johnny",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900496/anncjn_altair_anniversary_johnny.png"
+  },
+  {
+    "id": "anncty",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Taeyong",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900492/anncty_altair_anniversary_taeyong.png"
+  },
+  {
+    "id": "anncyt",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncyt_altair_anniversary_yuta.png"
+  },
+  {
+    "id": "anncdy",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Doyoung",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncdy_altair_anniversary_doyoung.png"
+  },
+  {
+    "id": "anncjw",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jungwoo",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900489/anncjw_altair_anniversary_jungwoo.png"
+  },
+  {
+    "id": "anncjh",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jaehyun",
+    "group": "NCT NCT127 127",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo VMAX",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900487/anncjh_altair_anniversary_jaehyun.png"
+  },
+  {
+    "id": "hbdyve",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Yuta",
+    "group": "NCT NCT127 127",
+    "types": ["Grass"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728725102/hbdyve_priceless_staff%20birthday_yuta.png"
+  }
+]

--- a/src/lib/database/superMLibrary.json
+++ b/src/lib/database/superMLibrary.json
@@ -1,0 +1,302 @@
+[
+  {
+    "id": "osmbh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Baekhyun",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160135/osmbh_ordinary_superm_baekhyun_ajmxbe.png"
+  },
+  {
+    "id": "osmka",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Kai",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160138/osmka_ordinary_superm_kai_df3fw4.png"
+  },
+  {
+    "id": "osmmk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Mark",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001535/osmmk_ordinary_superm_mark.png"
+  },
+  {
+    "id": "osmtm",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Taemin",
+    "group": "Shinee",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001550/osmtm_ordinary_superm_taemin.png"
+  },
+  {
+    "id": "osmtn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Ten",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001564/osmtn_ordinary_superm_ten.png"
+  },
+  {
+    "id": "osmty",
+    "cardRarity": "Ordinary",
+    "cardGroup": "SuperM",
+    "name": "Taeyong",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001579/osmty_ordinary_superm_taeyong.png"
+  },
+  {
+    "id": "usmbh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Baekhyun",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160143/usmbh_unordinary_superm_baekhyun_v1n2aq.png"
+  },
+  {
+    "id": "usmka",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Kai",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160147/usmka_unordinary_superm_kai_gbpmfl.png"
+  },
+  {
+    "id": "usmmk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Mark",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001698/usmmk_unordinary_superm_mark.png"
+  },
+  {
+    "id": "usmtm",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Taemin",
+    "group": "Shinee",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001714/usmtm_unordinary_superm_taemin.png"
+  },
+  {
+    "id": "usmtn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Ten",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001729/usmtn_unordinary_superm_ten.png"
+  },
+  {
+    "id": "usmty",
+    "cardRarity": "Unordinary",
+    "cardGroup": "SuperM",
+    "name": "Taeyong",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001746/usmty_unordinary_superm_taeyong.png"
+  },
+  {
+    "id": "rsmbh",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Baekhyun",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160227/rsmbh_rare_superm_baekhyun_s70oyp.png"
+  },
+  {
+    "id": "rsmka",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Kai",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160231/rsmka_rare_superm_kai_fhkz0x.png"
+  },
+  {
+    "id": "rsmmk",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Mark",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001594/rsmmk_rare_superm_mark.png"
+  },
+  {
+    "id": "rsmtm",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Taemin",
+    "group": "Shinee",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001608/rsmtm_rare_superm_taemin.png"
+  },
+  {
+    "id": "rsmtn",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Ten",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001623/rsmtn_rare_superm_ten.png"
+  },
+  {
+    "id": "rsmty",
+    "cardRarity": "Rare",
+    "cardGroup": "SuperM",
+    "name": "Taeyong",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729003097/rsmty_rare_superm_taeyong_1_vg1hkx.png"
+  },
+  {
+    "id": "ssmbh",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Baekhyun",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160236/ssmbh_special_superm_baekhyun_k08vak.png"
+  },
+  {
+    "id": "ssmka",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Kai",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160239/ssmka_special_superm_kai_yg3ctm.png"
+  },
+  {
+    "id": "ssmmk",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Mark",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001638/ssmmk_special_superm_mark.png"
+  },
+  {
+    "id": "ssmtm",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Taemin",
+    "group": "Shinee",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001652/ssmtm_special_superm_taemin.png"
+  },
+  {
+    "id": "ssmtn",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Ten",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001668/ssmtn_special_superm_ten.png"
+  },
+  {
+    "id": "ssmty",
+    "cardRarity": "Special",
+    "cardGroup": "SuperM",
+    "name": "Taeyong",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001684/ssmty_special_superm_taeyong.png"
+  },
+  {
+    "id": "esmbh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Baekhyun",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160244/esmbh_extraordinary_superm_baekhyun_fusbmj.png"
+  },
+  {
+    "id": "esmka",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Kai",
+    "group": "EXO",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160247/esmka_extraordinary_superm_kai_esgs4w.png"
+  },
+  {
+    "id": "esmmk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Mark",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001469/esmmk_extraordinary_superm_mark.png"
+  },
+  {
+    "id": "esmtm",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Taemin",
+    "group": "Shinee",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001481/esmtm_extraordinary_superm_taemin.png"
+  },
+  {
+    "id": "esmtn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Ten",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001496/esmtn_extraordinary_superm_ten.png"
+  },
+  {
+    "id": "esmty",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "SuperM",
+    "name": "Taeyong",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001509/esmty_extraordinary_superm_taeyong.png"
+  }
+]

--- a/src/lib/database/svtLibrary.json
+++ b/src/lib/database/svtLibrary.json
@@ -1602,7 +1602,7 @@
     {
       "id": "sumdin",
       "cardRarity": "Priceless",
-      "cardGroup": "Bsummer",
+      "cardGroup": "Summer Event Bsummer",
       "name": "Dino",
       "group": "Seventeen",
       "types": ["Metal"],
@@ -1612,7 +1612,7 @@
     {
       "id": "xodin",
       "cardRarity": "Priceless",
-      "cardGroup": "XOXO",
+      "cardGroup": "XOXO Event",
       "name": "Dino",
       "group": "Seventeen",
       "types": ["Fairy"],
@@ -1632,7 +1632,7 @@
     {
       "id": "apfshi",
       "cardRarity": "Priceless",
-      "cardGroup": "Apf",
+      "cardGroup": "April Fools Event Apf",
       "name": "Hoshi",
       "group": "Seventeen",
       "types": ["Fairy"],
@@ -1642,7 +1642,7 @@
     {
       "id": "xmhsi",
       "cardRarity": "Priceless",
-      "cardGroup": "Xmas23",
+      "cardGroup": "Xmas Xmas23",
       "name": "Hoshi",
       "group": "Seventeen",
       "types": ["Fire"],
@@ -1652,7 +1652,7 @@
     {
       "id": "evghan",
       "cardRarity": "Priceless",
-      "cardGroup": "Evil",
+      "cardGroup": "Evil Event",
       "name": "Jeonghan",
       "group": "Seventeen",
       "types": ["Darkness"],
@@ -1662,7 +1662,7 @@
     {
       "id": "faejhn",
       "cardRarity": "Priceless",
-      "cardGroup": "Bfairies",
+      "cardGroup": "Fairy Fairies Event Bfairies",
       "name": "Jeonghan",
       "group": "Seventeen",
       "types": ["Fairy"],
@@ -1742,7 +1742,7 @@
     {
       "id": "sfmami",
       "cardRarity": "Priceless",
-      "cardGroup": "Staffmate",
+      "cardGroup": "Staffmate Event",
       "name": "Joshua",
       "group": "Seventeen",
       "types": ["Fire"],
@@ -1812,7 +1812,7 @@
     {
       "id": "cdythe",
       "cardRarity": "Priceless",
-      "cardGroup": "Bcandy",
+      "cardGroup": "Candy Event Bcandy",
       "name": "The8",
       "group": "Seventeen",
       "types": ["Psychic"],
@@ -1862,7 +1862,7 @@
     {
       "id": "apover",
       "cardRarity": "Priceless",
-      "cardGroup": "Papocalypse",
+      "cardGroup": "Apocalypse Event Papocalypse",
       "name": "Vernon",
       "group": "Seventeen",
       "types": ["Metal"],
@@ -1872,7 +1872,7 @@
     {
       "id": "sfmshy",
       "cardRarity": "Priceless",
-      "cardGroup": "Staffmate",
+      "cardGroup": "Staffmate Event",
       "name": "Vernon",
       "group": "Seventeen",
       "types": ["Fairy"],
@@ -1902,7 +1902,7 @@
     {
       "id": "slmwwo",
       "cardRarity": "Priceless",
-      "cardGroup": "Soulmate",
+      "cardGroup": "Soulmate Event",
       "name": "Wonwoo",
       "group": "Seventeen",
       "types": ["Fairy"],
@@ -1932,7 +1932,7 @@
     {
       "id": "sfmnco",
       "cardRarity": "Priceless",
-      "cardGroup": "Staffmate",
+      "cardGroup": "Staffmate Event",
       "name": "Woozi",
       "group": "Seventeen",
       "types": ["Fairy"],

--- a/src/lib/helpers/cardDataGenerator.js
+++ b/src/lib/helpers/cardDataGenerator.js
@@ -2,18 +2,6 @@ import { writeFileSync } from 'fs';
 
 // 1. Declare a list of several img URLs.
 const imageUrls = [
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053091/e2exbh_extraordinary_exo_baekhyun.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053097/e2excn_extraordinary_exo_chen.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977870/e2excy_extraordinary_exo_chanyeol.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053106/e2exdo_extraordinary_exo_do.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053118/e2exka_extraordinary_exo_kai.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053124/e2exla_extraordinary_exo_lay.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053131/e2exlh_extraordinary_exo_luhan.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977782/e2exsh_extraordinary_exo_sehun.png",
-    "https://res.cloudinary.com/djg9bhuwi/image/upload/v1724977950/e2exsu_extraordinary_exo_suho.png",
-"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725053137/e2exto_extraordinary_exo_tao.png"
-    
-    
 ];
 
 // Helper function to map the card rarity to display names
@@ -40,10 +28,11 @@ function generateCards(imageUrls) {
     const card = {
       id: id,
       cardRarity: rarityMap[cardRarityKey.toLowerCase()],
-      cardGroup: cardGroupRaw.toLowerCase() === 'exo' ? 'EXO' : cardGroupRaw.charAt(0).toUpperCase() + cardGroupRaw.slice(1),
+      //cardGroup: "placeholder",
+      cardGroup: cardGroupRaw.toLowerCase() === 'nct dream' ? 'NCT Dream' : cardGroupRaw.charAt(0).toUpperCase() + cardGroupRaw.slice(1),
       name: name === 'do' ? 'D.O.' : name.charAt(0).toUpperCase() + name.slice(1), // Capitalize name
-      group: "EXO", // DON'T FORGET TO CHANGE THIS FOR DIFFERENT GROUPS
-      types: [], 
+      group: "NCT placeholder", // DON'T FORGET TO CHANGE THIS FOR DIFFERENT GROUPS
+      types: "", 
       rarity: "", 
       card_img: url
     };
@@ -72,6 +61,84 @@ function generateCards(imageUrls) {
           card.rarity = "Trainer Gallery Rare Holo";
           break;
     }
+
+    
+    // Why does this NCT lot have so many freakin members bloody hell
+    switch (name.toLowerCase()) {
+      case "chenle":
+        card.group = "NCT Dream";
+        break;
+      case "doyoung":
+        card.group = "NCT NCT127";
+        break;
+      case "haechan":
+        card.group = "NCT Dream NCT127";
+        break;
+      case "hendery":
+        card.group = "NCT WayV";
+        break;
+      case "jaehyun":
+        card.group = "NCT NCT127";
+        break;
+      case "jaehee":
+        card.group = "NCT WISH";
+        break;
+      case "jaemin":
+        card.group = "NCT Dream";
+        break;
+      case "jeno":
+        card.group = "NCT Dream";
+        break;
+      case "jisung":
+        card.group = "NCT Dream";
+        break;
+      case "johnny":
+        card.group = "NCT NCT127";
+        break;
+      case "jungwoo":
+        card.group = "NCT NCT127";
+        break;
+      case "kun":
+        card.group = "NCT WayV";
+        break;
+      case "mark":
+        card.group = "NCT Dream NCT127";
+        break;
+      case "renjun":
+        card.group = "NCT Dream";
+        break;
+      case "riku":
+        card.group = "NCT Dream";
+        break;
+      case "ryo":
+        card.group = "NCT WISH";
+        break;
+      case "sakuya":
+        card.group = "NCT WISH";
+        break;
+      case "sion":
+        card.group = "NCT WISH";
+        break;
+      case "taeyong":
+        card.group = "NCT NCT127";
+        break;
+      case "ten":
+        card.group = "NCT WayV";
+        break;
+      case "winwin":
+        card.group = "NCT WayV NCT127";
+        break;
+      case "xiaojun":
+        card.group = "NCT WayV";
+        break;
+      case "yangyang":
+        card.group = "NCT WayV";
+        break;
+      case "yuta":
+        card.group = "NCT NCT127";
+        break;               
+      }
+      
 
     return card;
   });

--- a/src/lib/helpers/cardDataModifier.js
+++ b/src/lib/helpers/cardDataModifier.js
@@ -1,0 +1,39 @@
+import { writeFileSync } from 'fs';
+
+
+
+const cards = [];
+
+
+// Modify the data
+cards.forEach(card => {
+  if (card.name === "Mark" || card.name === "Haechan") {
+    card.group = "NCT Dream NCT127";
+  }
+  else if (card.name === "Chenle" || card.name === "Jaemin" || card.name === "Jeno" || card.name === "Jisung"
+  || card.name === "Renjun" || card.name === "Riku") {
+    card.group = "NCT Dream";
+  }
+  else if (card.name === "Jaehee" || card.name === "Ryo" || card.name === "Sakuya" || card.name === "Sion") {
+    card.group = "NCT WISH";
+  }
+  else if (card.name === "Doyoung" || card.name === "Jaehyun" || card.name === "Johnny" || card.name === "Jungwoo"
+  || card.name === "Taeyong" || card.name === "Yuta") {
+    card.group = "NCT NCT127";
+  }
+  else if (card.name === "Winwin") {
+    card.group = "NCT WayV NCT127";
+  }
+  else if (card.name === "Hendery" || card.name === "Kun" || card.name === "Ten" || card.name === "Xiaojun"
+  || card.name === "Yangyang" || card.name === "Riku") {
+    card.group = "NCT WayV";
+  }
+});
+
+
+const jsonContent = JSON.stringify(cards, null, 2);
+
+//Write the JSON string to a file named 'sorted_cards.json'
+writeFileSync('modified_cards.json', jsonContent, 'utf-8');
+
+console.log('Output written to modified_cards.json');

--- a/src/lib/helpers/cardReorder.js
+++ b/src/lib/helpers/cardReorder.js
@@ -1,16 +1,19 @@
 import { writeFileSync } from 'fs';
 
-const cards = []
-  ;
+//const cards = require('src/lib/database/nctLibrary.json');
+const cards = require('./card_data.json');
   
   // Define the order for each property
-  const groupOrder = ["EXO", "EXO-CBX", "EXO-SC", "SuperM", "Soloist"];
+  //const groupOrder = ["EXO", "EXO-CBX", "EXO-SC", "SuperM", "Soloist"];
+  const groupOrder = ["NCT127", "NCT Dream", "WayV", "KUN&XIAOJUN", "Soloist"];
   const rarityOrder = ["Ordinary", "Unordinary", "Rare", "Special", "Extraordinary", "Priceless", "Altair"];
-  const nameOrder = ["Baekhyun", "Chen", "Chanyeol", "D.O.", "Kai", "Lay", "Luhan", "Sehun", "Suho", "Tao", "Xiumin"];
-  
+  //const nameOrder = ["Baekhyun", "Chen", "Chanyeol", "D.O.", "Kai", "Lay", "Luhan", "Sehun", "Suho", "Tao", "Xiumin"];
+  const nameOrder = ["Chenle", "Doyoung", "Haechan", "Hendery", "Jaehyun", "Jaemin", "Jeno", "Jisung", "Johnny", "Jungwoo",
+  "Kun", "Mark", "Renjun", "Riku", "Ryo", "Sakuya", "Sion", "Taeyong", "Ten", "Winwin", "Xiaojun", "Yangyang", "Yuta"];
+
   // Sorting
   cards.sort((a, b) => {
-    const groupDiff = groupOrder.indexOf(a.group) - groupOrder.indexOf(b.group);
+    const groupDiff = groupOrder.indexOf(a.cardGroup) - groupOrder.indexOf(b.cardGroup);
     if (groupDiff !== 0) return groupDiff;
     
     const rarityDiff = rarityOrder.indexOf(a.cardRarity) - rarityOrder.indexOf(b.cardRarity);


### PR DESCRIPTION
Added all NCT cards: NCT127, NCT Dream, NCT WISH, WayV, KUN&XIAOJUN, Soloist, and event cards.

Optimised all EXO cards; the file sizes has been drastically reduced.
All cards added in this update are optimised.

Created a separate SuperM Library. Relocated SuperM cards in the EXO Library to the new library.
Added previously missing SuperM cards as well.

A few cards are now easily searchable. For instance, portrait Suho.

cardDataModifier.js has been created. It should be useful in the future.

It is time I changed the structure of Card; new variables like 'keyword' and 'category' should be added in the next update.
"category": "Regular" or "Event" or "Gemstone"
"keyword": "exo" or "exo-cbx" or "cbx" 