### PR TITLE
json field update & re-added new cards

### DIFF
--- a/src/Cards.svelte
+++ b/src/Cards.svelte
@@ -98,8 +98,18 @@
 		:global( .card-grid > .card:nth-child(n+52):nth-child(-n+54) ) { grid-row: 18; }
 		:global( .card-grid > .card:nth-child(n+55):nth-child(-n+57) ) { grid-row: 19; }
 		:global( .card-grid > .card:nth-child(n+58):nth-child(-n+60) ) { grid-row: 20; }
+		:global( .card-grid > .card:nth-child(n+61):nth-child(-n+63) ) { grid-row: 21; }
+		:global( .card-grid > .card:nth-child(n+64):nth-child(-n+66) ) { grid-row: 22; }
+		:global( .card-grid > .card:nth-child(n+67):nth-child(-n+69) ) { grid-row: 23; }
+		:global( .card-grid > .card:nth-child(n+70):nth-child(-n+72) ) { grid-row: 24; }
+		:global( .card-grid > .card:nth-child(n+73):nth-child(-n+75) ) { grid-row: 25; }
+		:global( .card-grid > .card:nth-child(n+76):nth-child(-n+78) ) { grid-row: 26; }
+		:global( .card-grid > .card:nth-child(n+79):nth-child(-n+81) ) { grid-row: 27; }
+		:global( .card-grid > .card:nth-child(n+82):nth-child(-n+84) ) { grid-row: 28; }
+		:global( .card-grid > .card:nth-child(n+85):nth-child(-n+87) ) { grid-row: 29; }
+		:global( .card-grid > .card:nth-child(n+88):nth-child(-n+90) ) { grid-row: 30; }
 
-		:global( .card-grid > .card:nth-child(n+61) ) {
+		:global( .card-grid > .card:nth-child(n+91) ) {
 			grid-row: auto;
 			grid-column: auto;
 			transform: none!important;

--- a/src/Home.svelte
+++ b/src/Home.svelte
@@ -67,7 +67,9 @@
 			<p>
 				An <mark>unofficial card collection</mark>
 				for the Discord bot <a href="https://top.gg/bot/1120361339253162004">SUHO</a>.
-				The cards use <mark>3D transforms</mark>, <mark>filters</mark>, <mark>blend modes</mark>, <mark>css gradients</mark> and interactions to provide a unique experience when taking a closer look! <br/> <br/>
+				The cards use <strong>3D transforms</strong>, <strong>filters</strong>, <strong>blend modes</strong>, <strong>css gradients</strong> and interactions to provide a unique experience when taking a closer look. <br/> <br/>
+				
+				<mark>EXO</mark>, <mark>SuperM</mark>, <mark>NCT</mark>, and <mark>Seventeen</mark> cards are supported. <br/>
 				<mark>Firefox on PC</mark> is recommended for the best experience.<br/><br/>
 				Shoutout to <a href="https://github.com/simeydotme/pokemon-cards-css"> simeydotme</a> for the amazing repository :3
 			</p>
@@ -90,7 +92,7 @@
 		</div>
 
 		<section class="info">
-			<h2>Click on a Card to take a Closer Look!</h2>
+			<h2>Click on a Card to Take a Closer Look!</h2>
 
 			<hr />
 
@@ -119,8 +121,8 @@
 			<p>
 				
 				 <br/>
-				 <strong><mark>NCT joins our interactive card collection!</mark></strong><br />
-				 NCT127, NCT Dream, WayV, KUN&XIAOJUN, NCT WISH, Soloist, and all event cards are now searchable. <br />
+				 <mark>NCT joins our interactive card collection!</mark><br />
+				 <strong>NCT127</strong>, <strong>NCT Dream</strong>, <strong>WayV</strong>, <strong>KUN&XIAOJUN</strong>, <strong>NCT WISH</strong>, soloist, and all event cards are now searchable. <br />
 				 Typing <strong>only</strong> the 'NCT' keyword will fetch every aforementioned card, so specific keywords are preferred for your convenience. <br/>
 				 <br/>PS, all SuperM cards are also available.
 			</p>

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -51,7 +51,8 @@
 
           const matches = card => {
             const cardFullName = card.id.concat(' ', card.cardRarity,
-             ' ', card.cardGroup, ' ', card.group, ' ', card.name)
+             ' ', card.cardGroup, ' ', card.group, ' ', card.name, ' ', 
+             card.category, ' ', card.keyword)
             
             //Normalise the card name
             const cardTokens = cardFullName.toLowerCase().split(/\s+/);
@@ -128,7 +129,7 @@
 </section>
 
 {#if !query}
-  <h3>Browse cards below, Or search for your favourite! <br/>
+  <h3>Browse cards below, or search for your favourite! <br/>
       <strong>Note: the search term has to be an exact match.</strong> 
   </h3>
 {/if}

--- a/src/lib/components/CardProxy.svelte
+++ b/src/lib/components/CardProxy.svelte
@@ -5,11 +5,13 @@
   export let id = undefined;
   export let cardRarity = undefined;
   export let cardGroup = undefined;
-  export let name = undefined; //Artist name
+  export let name = undefined; // Artist name
   export let group = undefined; // The "root" group of an artist
-  export let types = undefined; //Card outline colour (Pokemon types)
-  export let rarity = undefined; //Foil effect based on the rarities of Pokemon cards.
-  export let isReverse = false;
+  export let types = undefined; // Card outline colour (Pokemon types)
+  export let rarity = undefined; // Foil effect based on the rarities of Pokemon cards.
+  export let category = undefined; // Regular or Event or Gemstones?
+  export let keyword = undefined; // Search tokens
+  //export let isReverse = false;
 
   // image props
   export let img = undefined;
@@ -44,6 +46,8 @@
     group,
     types,
     rarity,
+    category,
+    keyword,
     showcase
 
   }

--- a/src/lib/database/exoLibrary.json
+++ b/src/lib/database/exoLibrary.json
@@ -5,11 +5,11 @@
     "cardGroup": "EXO",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651509/o2exbh_ordinary_exo_baekhyun_nroqxs.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651509/o2exbh_ordinary_exo_baekhyun_nroqxs.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexbh",
@@ -17,11 +17,11 @@
     "cardGroup": "EXO",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649926/oexbh_ordinary_exo_baekhyun_w6mgeo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649926/oexbh_ordinary_exo_baekhyun_w6mgeo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslbk",
@@ -29,11 +29,11 @@
     "cardGroup": "Soloist",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Fighting"
-    ],
+    "types": ["Fighting"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153041/oslbk_ordinary_soloist_baekhyun_qxpdia.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153041/oslbk_ordinary_soloist_baekhyun_qxpdia.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2excn",
@@ -41,11 +41,11 @@
     "cardGroup": "EXO",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651523/o2excn_ordinary_exo_chen_kutulo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651523/o2excn_ordinary_exo_chen_kutulo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexcn",
@@ -53,11 +53,11 @@
     "cardGroup": "EXO",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649946/oexcn_ordinary_exo_chen_y0qkys.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649946/oexcn_ordinary_exo_chen_y0qkys.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslcn",
@@ -65,11 +65,11 @@
     "cardGroup": "Soloist",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Dragon"
-    ],
+    "types": ["Dragon"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153723/oslcn_ordinary_soloist_chen_nhivog.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153723/oslcn_ordinary_soloist_chen_nhivog.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2excy",
@@ -77,11 +77,11 @@
     "cardGroup": "EXO",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651673/o2excy_ordinary_exo_chanyeol_ptgqmj.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651673/o2excy_ordinary_exo_chanyeol_ptgqmj.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexcy",
@@ -89,11 +89,11 @@
     "cardGroup": "EXO",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649963/oexcy_ordinary_exo_chanyeol_augfpi.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649963/oexcy_ordinary_exo_chanyeol_augfpi.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslyl",
@@ -101,11 +101,11 @@
     "cardGroup": "Soloist",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153762/oslyl_ordinary_soloist_chanyeol_vwhdcd.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153762/oslyl_ordinary_soloist_chanyeol_vwhdcd.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exdo",
@@ -113,11 +113,11 @@
     "cardGroup": "EXO",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651687/o2exdo_ordinary_exo_do_iplwlk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651687/o2exdo_ordinary_exo_do_iplwlk.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexdo",
@@ -125,11 +125,11 @@
     "cardGroup": "EXO",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649977/oexdo_ordinary_exo_do_vpiyli.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649977/oexdo_ordinary_exo_do_vpiyli.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "osldo",
@@ -137,11 +137,11 @@
     "cardGroup": "Soloist",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153825/osldo_ordinary_soloist_do_lfv6oc.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153825/osldo_ordinary_soloist_do_lfv6oc.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exka",
@@ -153,7 +153,9 @@
       "Darkness"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651704/o2exka_ordinary_exo_kai_rutwjf.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651704/o2exka_ordinary_exo_kai_rutwjf.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexka",
@@ -165,7 +167,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649993/oexka_ordinary_exo_kai_kucdzd.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728649993/oexka_ordinary_exo_kai_kucdzd.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslki",
@@ -177,7 +181,9 @@
       "Water"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153849/oslki_ordinary_soloist_kai_nfveqr.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153849/oslki_ordinary_soloist_kai_nfveqr.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exla",
@@ -189,7 +195,9 @@
       "Darkness"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651723/o2exla_ordinary_exo_lay_ahwadf.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651723/o2exla_ordinary_exo_lay_ahwadf.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexla",
@@ -201,7 +209,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650008/oexla_ordinary_exo_lay_d2u3fo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650008/oexla_ordinary_exo_lay_d2u3fo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslla",
@@ -213,7 +223,9 @@
       "Metal"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153862/oslla_ordinary_soloist_lay_ncs8fk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728153862/oslla_ordinary_soloist_lay_ncs8fk.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exlh",
@@ -225,7 +237,9 @@
       "Water"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651749/o2exlh_ordinary_exo_luhan_uxvbmj.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651749/o2exlh_ordinary_exo_luhan_uxvbmj.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exsh",
@@ -237,7 +251,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651765/o2exsh_ordinary_exo_sehun_dqhsld.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651765/o2exsh_ordinary_exo_sehun_dqhsld.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexsh",
@@ -249,7 +265,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650029/oexsh_ordinary_exo_sehun_qjzqpk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650029/oexsh_ordinary_exo_sehun_qjzqpk.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exsu",
@@ -258,10 +276,11 @@
     "name": "Suho",
     "group": "EXO",
     "types": [
-      "Metal"
-    ],
+      "Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651814/o2exsu_ordinary_exo_suho_amln5j.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651814/o2exsu_ordinary_exo_suho_amln5j.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexsu",
@@ -273,7 +292,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650070/oexsu_ordinary_exo_suho_dbwwbm.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650070/oexsu_ordinary_exo_suho_dbwwbm.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2slsu",
@@ -281,9 +302,13 @@
     "cardGroup": "Soloist",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154769/o2slsu_ordinary_soloist_suho_hmzswz.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154769/o2slsu_ordinary_soloist_suho_hmzswz.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oslsu",
@@ -295,7 +320,9 @@
       "Lightning"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154073/oslsu_ordinary_soloist_suho_woqhcm.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154073/oslsu_ordinary_soloist_suho_woqhcm.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exto",
@@ -307,7 +334,9 @@
       "Darkness"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651827/o2exto_ordinary_exo_tao_zt97yy.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651827/o2exto_ordinary_exo_tao_zt97yy.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "o2exxm",
@@ -319,7 +348,9 @@
       "Water"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651842/o2exxm_ordinary_exo_xiumin_biexzy.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651842/o2exxm_ordinary_exo_xiumin_biexzy.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "oexxm",
@@ -331,7 +362,9 @@
       "Fire"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650086/oexxm_ordinary_exo_xiumin_ei63yo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650086/oexxm_ordinary_exo_xiumin_ei63yo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exbh",
@@ -343,7 +376,9 @@
       "Water"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652186/u2exbh_unordinary_exo_baekhyun_hrlkjz.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652186/u2exbh_unordinary_exo_baekhyun_hrlkjz.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexbh",
@@ -355,7 +390,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650212/uexbh_unordinary_exo_baekhyun_kviurk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650212/uexbh_unordinary_exo_baekhyun_kviurk.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslbk",
@@ -367,7 +404,9 @@
       "Fairy"
     ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154122/uslbk_unordinary_soloist_baekhyun_qswhpv.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154122/uslbk_unordinary_soloist_baekhyun_qswhpv.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2excn",
@@ -379,7 +418,9 @@
       "Water"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652275/u2excn_unordinary_exo_chen_xvf8to.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652275/u2excn_unordinary_exo_chen_xvf8to.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexcn",
@@ -391,7 +432,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650257/uexcn_unordinary_exo_chen_tu3zuq.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650257/uexcn_unordinary_exo_chen_tu3zuq.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslcn",
@@ -403,7 +446,9 @@
       "Metal"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154148/uslcn_unordinary_soloist_chen_rtexcl.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154148/uslcn_unordinary_soloist_chen_rtexcl.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2excy",
@@ -415,7 +460,9 @@
       "Water"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652293/u2excy_unordinary_exo_chanyeol_rdocos.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652293/u2excy_unordinary_exo_chanyeol_rdocos.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexcy",
@@ -427,7 +474,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650293/uexcy_unordinary_exo_chanyeol_uh9n3l.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650293/uexcy_unordinary_exo_chanyeol_uh9n3l.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslyl",
@@ -439,7 +488,9 @@
       "Fire"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154167/uslyl_unordinary_soloist_chanyeol_o2grce.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154167/uslyl_unordinary_soloist_chanyeol_o2grce.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exdo",
@@ -451,7 +502,9 @@
       "Fairy"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652457/u2exdo_unordinary_exo_do_k6mcdb.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652457/u2exdo_unordinary_exo_do_k6mcdb.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexdo",
@@ -463,7 +516,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650316/uexdo_unordinary_exo_do_voe0pr.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650316/uexdo_unordinary_exo_do_voe0pr.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "usldo",
@@ -475,7 +530,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154196/usldo_unordinary_soloist_do_mmvdk4.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154196/usldo_unordinary_soloist_do_mmvdk4.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exka",
@@ -487,7 +544,9 @@
       "Water"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652463/u2exka_unordinary_exo_kai_kk5obl.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652463/u2exka_unordinary_exo_kai_kk5obl.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexka",
@@ -499,7 +558,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650342/uexka_unordinary_exo_kai_pd7eq4.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650342/uexka_unordinary_exo_kai_pd7eq4.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslki",
@@ -511,7 +572,9 @@
       "Fairy"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154214/uslki_unordinary_soloist_kai_jjag5l.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154214/uslki_unordinary_soloist_kai_jjag5l.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exla",
@@ -523,7 +586,9 @@
       "Fairy"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652473/u2exla_unordinary_exo_lay_nt5y9r.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652473/u2exla_unordinary_exo_lay_nt5y9r.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexla",
@@ -535,7 +600,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650361/uexla_unordinary_exo_lay_obdv15.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650361/uexla_unordinary_exo_lay_obdv15.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslla",
@@ -547,7 +614,9 @@
       "Lightning"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154220/uslla_unordinary_soloist_lay_mk7tml.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154220/uslla_unordinary_soloist_lay_mk7tml.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exlh",
@@ -559,7 +628,9 @@
       "Fairy"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652490/u2exlh_unordinary_exo_luhan_vapyce.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652490/u2exlh_unordinary_exo_luhan_vapyce.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exsh",
@@ -571,7 +642,9 @@
       "Fairy"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652501/u2exsh_unordinary_exo_sehun_tnd2j8.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652501/u2exsh_unordinary_exo_sehun_tnd2j8.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexsh",
@@ -583,7 +656,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650380/uexsh_unordinary_exo_sehun_sunnks.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650380/uexsh_unordinary_exo_sehun_sunnks.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exsu",
@@ -595,7 +670,9 @@
       "Psychic"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652806/u2exsu_unordinary_exo_suho_g4zf8h.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652806/u2exsu_unordinary_exo_suho_g4zf8h.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexsu",
@@ -607,7 +684,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650404/uexsu_unordinary_exo_suho_jp7mhi.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650404/uexsu_unordinary_exo_suho_jp7mhi.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2slsu",
@@ -615,9 +694,13 @@
     "cardGroup": "Soloist",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Fighting"],
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154778/u2slsu_unordinary_soloist_suho_ndhiun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154778/u2slsu_unordinary_soloist_suho_ndhiun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uslsu",
@@ -629,7 +712,9 @@
       "Psychic"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154228/uslsu_unordinary_soloist_suho_ofl8zb.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154228/uslsu_unordinary_soloist_suho_ofl8zb.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exto",
@@ -641,7 +726,9 @@
       "Water"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652821/u2exto_unordinary_exo_tao_x7wgub.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652821/u2exto_unordinary_exo_tao_x7wgub.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "u2exxm",
@@ -653,7 +740,9 @@
       "Psychic"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652838/u2exxm_unordinary_exo_xiumin_ekvaar.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652838/u2exxm_unordinary_exo_xiumin_ekvaar.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uexxm",
@@ -665,7 +754,9 @@
       "Dragon"
     ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650418/uexxm_unordinary_exo_xiumin_ubtzwi.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650418/uexxm_unordinary_exo_xiumin_ubtzwi.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exbh",
@@ -677,7 +768,9 @@
       "Fighting"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653087/r2exbh_rare_exo_baekhyun_g7ig06.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653087/r2exbh_rare_exo_baekhyun_g7ig06.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexbh",
@@ -689,7 +782,9 @@
       "Dragon"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650455/rexbh_rare_exo_baekhyun_mfxilg.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650455/rexbh_rare_exo_baekhyun_mfxilg.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslbk",
@@ -701,7 +796,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154259/rslbk_rare_soloist_baekhyun_hjnuzs.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154259/rslbk_rare_soloist_baekhyun_hjnuzs.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2excn",
@@ -713,7 +810,9 @@
       "Fire"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653095/r2excn_rare_exo_chen_ewwak9.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653095/r2excn_rare_exo_chen_ewwak9.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexcn",
@@ -725,7 +824,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650543/rexcn_rare_exo_chen_nahwnf.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650543/rexcn_rare_exo_chen_nahwnf.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslcn",
@@ -737,7 +838,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154265/rslcn_rare_soloist_chen_rxvw1w.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154265/rslcn_rare_soloist_chen_rxvw1w.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2excy",
@@ -749,7 +852,9 @@
       "Darkness"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653105/r2excy_rare_exo_chanyeol_t6cvh4.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653105/r2excy_rare_exo_chanyeol_t6cvh4.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexcy",
@@ -761,7 +866,9 @@
       "Dragon"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650567/rexcy_rare_exo_chanyeol_hd2q1a.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650567/rexcy_rare_exo_chanyeol_hd2q1a.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslyl",
@@ -773,7 +880,9 @@
       "Fighting"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154271/rslyl_rare_soloist_chanyeol_us8o7v.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154271/rslyl_rare_soloist_chanyeol_us8o7v.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exdo",
@@ -785,7 +894,9 @@
       "Fighting"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653115/r2exdo_rare_exo_do_sg6cgp.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653115/r2exdo_rare_exo_do_sg6cgp.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexdo",
@@ -797,7 +908,9 @@
       "Dragon"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650591/rexdo_rare_exo_do_b6txzw.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650591/rexdo_rare_exo_do_b6txzw.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rsldo",
@@ -809,7 +922,9 @@
       "Grass"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154277/rsldo_rare_soloist_do_vwqgtn.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154277/rsldo_rare_soloist_do_vwqgtn.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exka",
@@ -819,7 +934,9 @@
     "group": "EXO",
     "types": [],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653124/r2exka_rare_exo_kai_skjkmw.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653124/r2exka_rare_exo_kai_skjkmw.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexka",
@@ -831,7 +948,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650612/rexka_rare_exo_kai_xc3h2q.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650612/rexka_rare_exo_kai_xc3h2q.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslki",
@@ -843,7 +962,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154283/rslki_rare_soloist_kai_zwug2v.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154283/rslki_rare_soloist_kai_zwug2v.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exla",
@@ -855,7 +976,9 @@
       "Fire"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653137/r2exla_rare_exo_lay_iienvd.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653137/r2exla_rare_exo_lay_iienvd.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslla",
@@ -867,7 +990,9 @@
       "Grass"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154290/rslla_rare_soloist_lay_j6zwiv.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154290/rslla_rare_soloist_lay_j6zwiv.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exsh",
@@ -879,7 +1004,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653194/r2exsh_rare_exo_sehun_nicnyo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653194/r2exsh_rare_exo_sehun_nicnyo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexsh",
@@ -891,7 +1018,9 @@
       "Water"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650637/rexsh_rare_exo_sehun_nfpakz.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650637/rexsh_rare_exo_sehun_nfpakz.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exsu",
@@ -903,7 +1032,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653204/r2exsu_rare_exo_suho_p1oqck.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653204/r2exsu_rare_exo_suho_p1oqck.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexsu",
@@ -911,19 +1042,27 @@
     "cardGroup": "EXO",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Fairy"],
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650659/rexsu_rare_exo_suho_pkzoih.png"
-  },  
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650659/rexsu_rare_exo_suho_pkzoih.png",
+    "category": "Regular",
+    "keyword": ""
+  },
   {
     "id": "r2slsu",
     "cardRarity": "Rare",
     "cardGroup": "Soloist",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154786/r2slsu_rare_soloist_suho_lducu9.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154786/r2slsu_rare_soloist_suho_lducu9.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rslsu",
@@ -935,7 +1074,9 @@
       "Psychic"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154297/rslsu_rare_soloist_suho_lvux18.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154297/rslsu_rare_soloist_suho_lvux18.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "r2exxm",
@@ -947,7 +1088,9 @@
       "Fire"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653212/r2exxm_rare_exo_xiumin_jbjogi.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653212/r2exxm_rare_exo_xiumin_jbjogi.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rexxm",
@@ -959,7 +1102,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650687/rexxm_rare_exo_xiumin_uoda2o.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650687/rexxm_rare_exo_xiumin_uoda2o.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eobh",
@@ -971,7 +1116,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653357/s2eobh_special_exo_baekhyun_wcur00.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653357/s2eobh_special_exo_baekhyun_wcur00.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seobh",
@@ -983,7 +1130,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650767/seobh_special_exo_baekhyun_qmvoca.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650767/seobh_special_exo_baekhyun_qmvoca.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslbk",
@@ -995,7 +1144,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154480/sslbk_special_soloist_baekhyun_u4dtlp.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154480/sslbk_special_soloist_baekhyun_u4dtlp.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eocn",
@@ -1007,7 +1158,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653402/s2eocn_special_exo_chen_rjlg1d.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653402/s2eocn_special_exo_chen_rjlg1d.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seocn",
@@ -1019,7 +1172,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650790/seocn_special_exo_chen_q1rmux.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650790/seocn_special_exo_chen_q1rmux.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslcn",
@@ -1031,7 +1186,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154486/sslcn_special_soloist_chen_kreeg1.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154486/sslcn_special_soloist_chen_kreeg1.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eocy",
@@ -1043,7 +1200,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653409/s2eocy_special_exo_chanyeol_taagvg.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653409/s2eocy_special_exo_chanyeol_taagvg.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seocy",
@@ -1055,7 +1214,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650827/seocy_special_exo_chanyeol_u4nhjm.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650827/seocy_special_exo_chanyeol_u4nhjm.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslyl",
@@ -1067,7 +1228,9 @@
       "Metal"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154492/sslyl_special_soloist_chanyeol_ycknpo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154492/sslyl_special_soloist_chanyeol_ycknpo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eodo",
@@ -1079,7 +1242,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653475/s2eodo_special_exo_do_tmae4t.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653475/s2eodo_special_exo_do_tmae4t.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seodo",
@@ -1091,7 +1256,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650886/seodo_special_exo_do_rqzovu.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650886/seodo_special_exo_do_rqzovu.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ssldo",
@@ -1103,7 +1270,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154498/ssldo_special_soloist_do_igugru.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154498/ssldo_special_soloist_do_igugru.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eoka",
@@ -1115,7 +1284,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653505/s2eoka_special_exo_kai_woyl6r.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653505/s2eoka_special_exo_kai_woyl6r.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seoka",
@@ -1127,7 +1298,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650902/seoka_special_exo_kai_hugsor.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650902/seoka_special_exo_kai_hugsor.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslki",
@@ -1139,7 +1312,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154505/sslki_special_soloist_kai_yowwkt.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154505/sslki_special_soloist_kai_yowwkt.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eola",
@@ -1151,7 +1326,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653539/s2eola_special_exo_lay_kbvm60.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653539/s2eola_special_exo_lay_kbvm60.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seola",
@@ -1163,7 +1340,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650928/seola_special_exo_lay_sgnmoz.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650928/seola_special_exo_lay_sgnmoz.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslla",
@@ -1175,7 +1354,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154512/sslla_special_soloist_lay_osa60u.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154512/sslla_special_soloist_lay_osa60u.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eolh",
@@ -1187,7 +1368,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653561/s2eolh_special_exo_luhan_ncgojr.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653561/s2eolh_special_exo_luhan_ncgojr.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seolh",
@@ -1199,7 +1382,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650955/seolh_special_exo_luhan_noet8v.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650955/seolh_special_exo_luhan_noet8v.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eosh",
@@ -1211,7 +1396,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653580/s2eosh_special_exo_sehun_qjsmdc.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653580/s2eosh_special_exo_sehun_qjsmdc.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seosh",
@@ -1223,7 +1410,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650986/seosh_special_exo_sehun_cnwa55.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728650986/seosh_special_exo_sehun_cnwa55.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eosu",
@@ -1235,7 +1424,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653610/s2eosu_special_exo_suho_gaaloe.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653610/s2eosu_special_exo_suho_gaaloe.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seosu",
@@ -1247,17 +1438,23 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651013/seosu_special_exo_suho_qzqbk4.png"
-  },  
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651013/seosu_special_exo_suho_qzqbk4.png",
+    "category": "Regular",
+    "keyword": ""
+  },
   {
     "id": "s2slsu",
     "cardRarity": "Special",
     "cardGroup": "Soloist",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Water"],
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154794/s2slsu_special_soloist_suho_jhg435.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154794/s2slsu_special_soloist_suho_jhg435.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sslsu",
@@ -1269,7 +1466,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154519/sslsu_special_soloist_suho_fmduoc.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154519/sslsu_special_soloist_suho_fmduoc.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eoto",
@@ -1281,7 +1480,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653653/s2eoto_special_exo_tao_wgxs2a.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653653/s2eoto_special_exo_tao_wgxs2a.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seoto",
@@ -1293,7 +1494,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652967/seoto_special_exo_tao_cdnwpe.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652967/seoto_special_exo_tao_cdnwpe.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "s2eoxm",
@@ -1305,7 +1508,9 @@
       "Fairy"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653661/s2eoxm_special_exo_xiumin_ud81am.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653661/s2eoxm_special_exo_xiumin_ud81am.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "seoxm",
@@ -1317,7 +1522,9 @@
       "Lightning"
     ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652973/seoxm_special_exo_xiumin_amylma.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728652973/seoxm_special_exo_xiumin_amylma.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exbh",
@@ -1329,7 +1536,9 @@
       "Psychic"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653734/e2exbh_extraordinary_exo_baekhyun_g3p1vo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653734/e2exbh_extraordinary_exo_baekhyun_g3p1vo.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexbh",
@@ -1341,7 +1550,9 @@
       "Dragon"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651078/eexbh_extraordinary_exo_baekhyun_gxy2hp.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651078/eexbh_extraordinary_exo_baekhyun_gxy2hp.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslbk",
@@ -1353,7 +1564,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154619/eslbk_extraordinary_soloist_baekhyun_tc6onx.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154619/eslbk_extraordinary_soloist_baekhyun_tc6onx.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2excn",
@@ -1365,7 +1578,9 @@
       "Darkness"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653788/e2excn_extraordinary_exo_chen_m4r7l3.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653788/e2excn_extraordinary_exo_chen_m4r7l3.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexcn",
@@ -1377,7 +1592,9 @@
       "Fighting"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651115/eexcn_extraordinary_exo_chen_hwbgza.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651115/eexcn_extraordinary_exo_chen_hwbgza.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslcn",
@@ -1389,7 +1606,9 @@
       "Lightning"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154625/eslcn_extraordinary_soloist_chen_v17tre.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154625/eslcn_extraordinary_soloist_chen_v17tre.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2excy",
@@ -1401,7 +1620,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653818/e2excy_extraordinary_exo_chanyeol_i59uax.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653818/e2excy_extraordinary_exo_chanyeol_i59uax.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexcy",
@@ -1413,7 +1634,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651149/eexcy_extraordinary_exo_chanyeol_qlcue9.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651149/eexcy_extraordinary_exo_chanyeol_qlcue9.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslyl",
@@ -1425,7 +1648,9 @@
       "Fighting"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154632/eslyl_extraordinary_soloist_chanyeol_jitkjf.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154632/eslyl_extraordinary_soloist_chanyeol_jitkjf.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exdo",
@@ -1437,7 +1662,9 @@
       "Psychic"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653826/e2exdo_extraordinary_exo_do_irgvxs.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653826/e2exdo_extraordinary_exo_do_irgvxs.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexdo",
@@ -1449,7 +1676,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651177/eexdo_extraordinary_exo_do_ypacjn.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651177/eexdo_extraordinary_exo_do_ypacjn.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "esldo",
@@ -1461,7 +1690,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154639/esldo_extraordinary_soloist_do_blxhb7.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154639/esldo_extraordinary_soloist_do_blxhb7.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exka",
@@ -1473,7 +1704,9 @@
       "Fairy"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653848/e2exka_extraordinary_exo_kai_ec95lt.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653848/e2exka_extraordinary_exo_kai_ec95lt.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexka",
@@ -1485,7 +1718,9 @@
       "Fighting"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651204/eexka_extraordinary_exo_kai_zo9dr8.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651204/eexka_extraordinary_exo_kai_zo9dr8.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslki",
@@ -1497,7 +1732,9 @@
       "Fighting"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154646/eslki_extraordinary_soloist_kai_bfgt41.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154646/eslki_extraordinary_soloist_kai_bfgt41.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exla",
@@ -1509,7 +1746,9 @@
       "Psychic"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653870/e2exla_extraordinary_exo_lay_cdkaas.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653870/e2exla_extraordinary_exo_lay_cdkaas.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexla",
@@ -1521,7 +1760,9 @@
       "Fighting"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651280/eexla_extraordinary_exo_lay_lwj9mx.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651280/eexla_extraordinary_exo_lay_lwj9mx.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslla",
@@ -1533,7 +1774,9 @@
       "Water"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154652/eslla_extraordinary_soloist_lay_trpeod.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154652/eslla_extraordinary_soloist_lay_trpeod.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exlh",
@@ -1545,7 +1788,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653870/e2exla_extraordinary_exo_lay_cdkaas.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653870/e2exla_extraordinary_exo_lay_cdkaas.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexlh",
@@ -1557,7 +1802,9 @@
       "Dragon"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651303/eexlh_extraordinary_exo_luhan_farn5x.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651303/eexlh_extraordinary_exo_luhan_farn5x.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exsh",
@@ -1569,7 +1816,9 @@
       "Water"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653945/e2exsh_extraordinary_exo_sehun_pr4c9o.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653945/e2exsh_extraordinary_exo_sehun_pr4c9o.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexsh",
@@ -1581,7 +1830,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651402/eexsh_extraordinary_exo_sehun_cd64bk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651402/eexsh_extraordinary_exo_sehun_cd64bk.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exsu",
@@ -1593,7 +1844,9 @@
       "Fairy"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653962/e2exsu_extraordinary_exo_suho_vpjffr.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653962/e2exsu_extraordinary_exo_suho_vpjffr.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexsu",
@@ -1605,17 +1858,23 @@
       "Water"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651426/eexsu_extraordinary_exo_suho_kypxzt.png"
-  },  
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651426/eexsu_extraordinary_exo_suho_kypxzt.png",
+    "category": "Regular",
+    "keyword": ""
+  },
   {
     "id": "e2slsu",
     "cardRarity": "Extraordinary",
     "cardGroup": "Soloist",
     "name": "Suho",
     "group": "EXO",
-    "types": ["Psychic"],
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154803/e2slsu_extraordinary_soloist_suho_wvcz3x.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154803/e2slsu_extraordinary_soloist_suho_wvcz3x.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eslsu",
@@ -1627,7 +1886,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154662/eslsu_extraordinary_soloist_suho_v5i9vt.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728154662/eslsu_extraordinary_soloist_suho_v5i9vt.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exto",
@@ -1639,7 +1900,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653974/e2exto_extraordinary_exo_tao_uems42.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653974/e2exto_extraordinary_exo_tao_uems42.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexto",
@@ -1651,7 +1914,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651436/eexto_extraordinary_exo_tao_sdkujm.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651436/eexto_extraordinary_exo_tao_sdkujm.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "e2exxm",
@@ -1663,7 +1928,9 @@
       "Metal"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653991/e2exxm_extraordinary_exo_xiumin_o2w32p.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728653991/e2exxm_extraordinary_exo_xiumin_o2w32p.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "eexxm",
@@ -1675,7 +1942,9 @@
       "Fire"
     ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651452/eexxm_extraordinary_exo_xiumin_zc0kxx.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728651452/eexxm_extraordinary_exo_xiumin_zc0kxx.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "feseho",
@@ -1687,7 +1956,9 @@
       "Darkness"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321877/feseho_priceless_sehun_suho_o8c7pe.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321877/feseho_priceless_sehun_suho_o8c7pe.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "roycdo",
@@ -1699,19 +1970,21 @@
       "Lightning"
     ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321129/roycdo_priceless_royal%20event_chanyeol%20do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321129/roycdo_priceless_royal%20event_chanyeol%20do.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "xmkyl",
     "cardRarity": "Priceless",
-    "cardGroup": "Xmas Xmas23 Bxmas23",
+    "cardGroup": "Bxmas23",
     "name": "Kai & Chanyeol",
     "group": "EXO",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320687/xmkyl_priceless_bxmas23_kai%20chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320687/xmkyl_priceless_bxmas23_kai%20chanyeol.png",
+    "category": "Event",
+    "keyword": "Xmas Xmas23 Christmas"
   },
   {
     "id": "psebh",
@@ -1719,23 +1992,23 @@
     "cardGroup": "Stardust Event",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319195/psebh_priceless_stardust_event_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319195/psebh_priceless_stardust_event_baekhyun.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evbaek",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event Pevil",
+    "cardGroup": "Pevil",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319863/evbaek_priceless_pevil_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319863/evbaek_priceless_pevil_baekhyun.png",
+    "category": "Event",
+    "keyword": "Evil"
   },
   {
     "id": "paqbh",
@@ -1743,11 +2016,11 @@
     "cardGroup": "Aphrodite",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728151463/paqbh_priceless_aphrodite_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728151463/paqbh_priceless_aphrodite_baekhyun.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "fmxmbh",
@@ -1755,11 +2028,11 @@
     "cardGroup": "Fanmade Xmas",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320605/fmxmbh_priceless_fanmade%20xmas_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320605/fmxmbh_priceless_fanmade%20xmas_baekhyun.png",
+    "category": "Event",
+    "keyword": "Christmas"
   },
   {
     "id": "emebae",
@@ -1767,11 +2040,11 @@
     "cardGroup": "Emerald",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319687/emebae_priceless_emerald_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319687/emebae_priceless_emerald_baekhyun.png",
+    "category": "Gemstone",
+    "keyword": "Event"
   },
   {
     "id": "tyubae",
@@ -1779,11 +2052,11 @@
     "cardGroup": "Thanku",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320445/tyubae_priceless_thanku_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320445/tyubae_priceless_thanku_baekhyun.png",
+    "category": "Event",
+    "keyword": "Thank You"
   },
   {
     "id": "sapchn",
@@ -1791,9 +2064,11 @@
     "cardGroup": "Sapphire",
     "name": "Chen",
     "group": "EXO",
-    "types": [""],
+    "types": ["Water"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321069/sapchn_priceless_sapphire_chen_zqmsio.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321069/sapchn_priceless_sapphire_chen_zqmsio.png",
+    "category": "Gemstone",
+    "keyword": "Event"
   },
   {
     "id": "psecn",
@@ -1801,23 +2076,23 @@
     "cardGroup": "Stardust Event",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319218/psecn_priceless_stardust_event_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319218/psecn_priceless_stardust_event_chen.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evchen",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event Bevil",
+    "cardGroup": "Bevil",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319883/evchen_priceless_bevil_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319883/evchen_priceless_bevil_chen.png",
+    "category": "Event",
+    "keyword": "Evil"
   },
   {
     "id": "virche",
@@ -1825,23 +2100,23 @@
     "cardGroup": "Virgo",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320944/virche_priceless_virgo_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320944/virche_priceless_virgo_chen.png",
+    "category": "Event",
+    "keyword": "Zodiac"
   },
   {
     "id": "faeche",
     "cardRarity": "Priceless",
-    "cardGroup": "Fairy Fairies Event Pfairies",
+    "cardGroup": "Pfairies",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321005/faeche_priceless_pfairies_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321005/faeche_priceless_pfairies_chen.png",
+    "category": "Event",
+    "keyword": "Fairy Fairies"
   },
   {
     "id": "psecy",
@@ -1849,23 +2124,23 @@
     "cardGroup": "Stardust Event",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319242/psecy_priceless_stardust%20event_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319242/psecy_priceless_stardust%20event_chanyeol.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evyeol",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Evil",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319902/evyeol_priceless_evil_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319902/evyeol_priceless_evil_chanyeol.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "sagcyl",
@@ -1873,11 +2148,11 @@
     "cardGroup": "Sagittarius",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321310/sagcyl_priceless_sagittarius_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321310/sagcyl_priceless_sagittarius_chanyeol.png",
+    "category": "Event",
+    "keyword": "Zodiac"
   },
   {
     "id": "srocyl",
@@ -1885,11 +2160,11 @@
     "cardGroup": "Sanrio",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "psedo",
@@ -1897,35 +2172,35 @@
     "cardGroup": "Stardust Event",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321371/srocyl_priceless_sanrio_chanyeol.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evdooo",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Evil",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319918/evdooo_priceless_evil_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319918/evdooo_priceless_evil_do.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "apodoo",
     "cardRarity": "Priceless",
-    "cardGroup": "Apocalypse Event Bapocalypse",
+    "cardGroup": "Bapocalypse",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321437/apodoo_priceless_bapocalypse_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321437/apodoo_priceless_bapocalypse_do.png",
+    "category": "Event",
+    "keyword": "Apocalypse"
   },
   {
     "id": "pseka",
@@ -1933,35 +2208,35 @@
     "cardGroup": "Stardust Event",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319330/pseka_priceless_stardust%20event_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319330/pseka_priceless_stardust%20event_kai.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evkaii",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event Pevil",
+    "cardGroup": "Pevil",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019578/evkaii_priceless_kai.gif"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725019578/evkaii_priceless_kai.gif",
+    "category": "Event",
+    "keyword": "Evil"
   },
   {
     "id": "xokai",
     "cardRarity": "Priceless",
-    "cardGroup": "XOXO Event PXOXO",
+    "cardGroup": "PXOXO",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321577/xokai_priceless_pxoxo_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321577/xokai_priceless_pxoxo_kai.png",
+    "category": "Event",
+    "keyword": "XOXO"
   },
   {
     "id": "fmxmka",
@@ -1969,11 +2244,11 @@
     "cardGroup": "Fanmade Xmas",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320792/fmxmka_priceless_fanmade%20xmas_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320792/fmxmka_priceless_fanmade%20xmas_kai.png",
+    "category": "Event",
+    "keyword": "Christmas"
   },
   {
     "id": "sfmatt",
@@ -1981,11 +2256,11 @@
     "cardGroup": "Staffmate Event",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321650/sfmatt_priceless_staffmate_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321650/sfmatt_priceless_staffmate_kai.png",
+    "category": "Event",
+    "keyword": "Staff Mate"
   },
   {
     "id": "psela",
@@ -1993,23 +2268,23 @@
     "cardGroup": "Stardust Event",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319384/psela_priceless_stardust%20event_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319384/psela_priceless_stardust%20event_lay.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evlayy",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Evil",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320043/evlayy_priceless_evil_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320043/evlayy_priceless_evil_lay.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "roylay",
@@ -2019,7 +2294,9 @@
     "group": "EXO",
     "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729332347/roylay_priceless_royal%20event_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729332347/roylay_priceless_royal%20event_lay.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "liblay",
@@ -2027,47 +2304,47 @@
     "cardGroup": "Libra",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321774/liblay_priceless_libra_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321774/liblay_priceless_libra_lay.png",
+    "category": "Event",
+    "keyword": "Zodiac"
   },
   {
     "id": "xmlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Xmas Xmas23",
+    "cardGroup": "Xmas23",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320813/xmlay_priceless_xmas23_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320813/xmlay_priceless_xmas23_lay.png",
+    "category": "Event",
+    "keyword": "Xmas Christmas"
   },
   {
     "id": "slmlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Soulmate Event Psoulmate",
+    "cardGroup": "Psoulmate",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321821/slmlay_priceless_psoulmate_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321821/slmlay_priceless_psoulmate_lay.png",
+    "category": "Event",
+    "keyword": "Soulmate Soul Mate"
   },
   {
     "id": "sumlay",
     "cardRarity": "Priceless",
-    "cardGroup": "Summer Event Bsummer",
+    "cardGroup": "Bsummer",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321719/sumlay_priceless_bsummer_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321719/sumlay_priceless_bsummer_lay.png",
+    "category": "Event",
+    "keyword": "Summer"
   },
   {
     "id": "psesh",
@@ -2075,35 +2352,35 @@
     "cardGroup": "Stardust Event",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319399/psesh_priceless_stardust%20event_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319399/psesh_priceless_stardust%20event_sehun.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evehun",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event Bevil",
+    "cardGroup": "Bevil",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320068/evehun_priceless_bevil_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320068/evehun_priceless_bevil_sehun.png",
+    "category": "Event",
+    "keyword": "Evil"
   },
   {
     "id": "cdyshn",
     "cardRarity": "Priceless",
-    "cardGroup": "Candy Event",
+    "cardGroup": "Candy",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321982/cdyshn_priceless_candy_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321982/cdyshn_priceless_candy_sehun.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "diaseh",
@@ -2111,11 +2388,11 @@
     "cardGroup": "Diamond",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321927/diaseh_priceless_diamond_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321927/diaseh_priceless_diamond_sehun.png",
+    "category": "Gemstone",
+    "keyword": "Event"
   },
   {
     "id": "psesu",
@@ -2123,35 +2400,35 @@
     "cardGroup": "Stardust Event",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319419/psesu_priceless_stardust%20event_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319419/psesu_priceless_stardust%20event_suho.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "evsuho",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Evil",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320077/evsuho_priceless_evil_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729320077/evsuho_priceless_evil_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "aposuh",
     "cardRarity": "Priceless",
-    "cardGroup": "Apocalypse Event",
+    "cardGroup": "Apocalypse",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321448/aposuh_priceless_apocalypse_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729321448/aposuh_priceless_apocalypse_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "emesuh",
@@ -2159,23 +2436,23 @@
     "cardGroup": "Emerald",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Green"
-    ],
+    "types": ["Green"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319703/emesuh_priceless_emerald_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319703/emesuh_priceless_emerald_suho.png",
+    "category": "Gemstone",
+    "keyword": "Event"
   },
   {
     "id": "btasuh",
     "cardRarity": "Priceless",
-    "cardGroup": "BTA Event",
+    "cardGroup": "BTA",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322246/btasuh_priceless_bta_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322246/btasuh_priceless_bta_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "1KSUHO",
@@ -2183,11 +2460,11 @@
     "cardGroup": "1k Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322055/1KSUHO_priceless_1k%20special_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322055/1KSUHO_priceless_1k%20special_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "2KSUHO",
@@ -2195,11 +2472,11 @@
     "cardGroup": "2k Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322069/2KSUHO_priceless_2k%20special_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322069/2KSUHO_priceless_2k%20special_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "3KSUHO",
@@ -2207,23 +2484,23 @@
     "cardGroup": "3k Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322125/3KSUHO_priceless_3k%20special_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322125/3KSUHO_priceless_3k%20special_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "hbdasaki",
     "cardRarity": "Priceless",
-    "cardGroup": "Staff Birthday Event",
+    "cardGroup": "Staff Birthday",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322184/hbdasaki_priceless_staff%20birthday_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322184/hbdasaki_priceless_staff%20birthday_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "psexm",
@@ -2231,11 +2508,11 @@
     "cardGroup": "Stardust Event",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319427/psexm_priceless_stardust%20event_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319427/psexm_priceless_stardust%20event_xiumin.png",
+    "category": "Event",
+    "keyword": "Star Dust"
   },
   {
     "id": "zuhxmn",
@@ -2243,11 +2520,11 @@
     "cardGroup": "Cardcaptor",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322783/zuhxmn_priceless_cardcaptor_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322783/zuhxmn_priceless_cardcaptor_xiumin.png",
+    "category": "Event",
+    "keyword": "Card Captor"
   },
   {
     "id": "aquxiu",
@@ -2255,23 +2532,23 @@
     "cardGroup": "Aquamarine",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Grass"
-    ],
+    "types": ["Grass"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322669/aquxiu_priceless_aquamarine_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322669/aquxiu_priceless_aquamarine_xiumin.png",
+    "category": "Gemstone",
+    "keyword": "Event"
   },
   {
     "id": "apfxiu",
     "cardRarity": "Priceless",
-    "cardGroup": "April Fools Event Bapf",
+    "cardGroup": "Bapf",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322721/apfxiu_priceless_bapf_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322721/apfxiu_priceless_bapf_xiumin.png",
+    "category": "Event",
+    "keyword": "April Fools"
   },
   {
     "id": "anexbh",
@@ -2279,11 +2556,11 @@
     "cardGroup": "Anniversary",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318712/anexbh_altair_anniversary_baekhyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318712/anexbh_altair_anniversary_baekhyun.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrsbh",
@@ -2291,11 +2568,11 @@
     "cardGroup": "EXO Day",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318265/12yrsbh_altair_anniversary_baekhyun_jgbzmo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318265/12yrsbh_altair_anniversary_baekhyun_jgbzmo.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexch",
@@ -2303,11 +2580,11 @@
     "cardGroup": "Anniversary",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318750/anexch_altair_anniversary_chen.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318750/anexch_altair_anniversary_chen.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrsch",
@@ -2315,11 +2592,11 @@
     "cardGroup": "EXO Day",
     "name": "Chen",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318290/12yrsch_altair_anniversary_chen_qecx1x.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318290/12yrsch_altair_anniversary_chen_qecx1x.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexcy",
@@ -2327,11 +2604,11 @@
     "cardGroup": "Anniversary",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318796/anexcy_altair_anniversary_chanyeol.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318796/anexcy_altair_anniversary_chanyeol.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrscy",
@@ -2339,11 +2616,11 @@
     "cardGroup": "EXO Day",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318310/12yrscy_altair_anniversary_chanyeol_ybrrev.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318310/12yrscy_altair_anniversary_chanyeol_ybrrev.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexdo",
@@ -2351,11 +2628,11 @@
     "cardGroup": "Anniversary",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318838/anexdo_altair_anniversary_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318838/anexdo_altair_anniversary_do.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrsdo",
@@ -2363,11 +2640,11 @@
     "cardGroup": "EXO Day",
     "name": "D.O.",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318327/12yrsdo_altair_anniversary_do.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318327/12yrsdo_altair_anniversary_do.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexka",
@@ -2375,11 +2652,11 @@
     "cardGroup": "Anniversary",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318871/anexka_altair_anniversary_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318871/anexka_altair_anniversary_kai.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrska",
@@ -2387,11 +2664,11 @@
     "cardGroup": "EXO Day",
     "name": "Kai",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318342/12yrska_altair_anniversary_kai.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318342/12yrska_altair_anniversary_kai.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexla",
@@ -2399,11 +2676,11 @@
     "cardGroup": "Anniversary",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318905/anexla_altair_anniversary_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318905/anexla_altair_anniversary_lay.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrsla",
@@ -2411,11 +2688,11 @@
     "cardGroup": "EXO Day",
     "name": "Lay",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318364/12yrsla_altair_anniversary_lay.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318364/12yrsla_altair_anniversary_lay.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexsh",
@@ -2423,11 +2700,11 @@
     "cardGroup": "Anniversary",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318959/anexsh_altair_anniversary_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318959/anexsh_altair_anniversary_sehun.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrssh",
@@ -2435,11 +2712,11 @@
     "cardGroup": "EXO Day",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318380/12yrssh_altair_anniversary_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318380/12yrssh_altair_anniversary_sehun.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "anexsu",
@@ -2447,11 +2724,11 @@
     "cardGroup": "Anniversary",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318995/anexsu_altair_anniversary_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318995/anexsu_altair_anniversary_suho.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrssu",
@@ -2459,11 +2736,11 @@
     "cardGroup": "EXO Day",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318395/12yrssu_altair_anniversary_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318395/12yrssu_altair_anniversary_suho.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "bunsuho",
@@ -2471,13 +2748,13 @@
     "cardGroup": "Fanmade Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322333/bunsuho_altair_fanmade%20special_suho.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "castlesuho",
@@ -2485,14 +2762,14 @@
     "cardGroup": "Fanmade Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Rare Holo VMAX",
     "isTrainer": "true",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322358/castlesuho_altair_fanmade%20special_suho.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "minisuho",
@@ -2500,25 +2777,25 @@
     "cardGroup": "Fanmade Special",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322374/minisuho_altair_fanmade%20special_suho.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "p0rtr4it",
     "cardRarity": "Altair",
     "cardGroup": "Fanmade Special",
-    "name": "Suho portrait",
+    "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322571/p0rtr4it_altair_fanmade%20special_suho.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322571/p0rtr4it_altair_fanmade%20special_suho.png",
+    "category": "Event",
+    "keyword": "portrait"
   },
   {
     "id": "starsuho",
@@ -2526,13 +2803,13 @@
     "cardGroup": "Starry Night",
     "name": "Suho",
     "group": "EXO",
-    "types": [
-      "Psychic"
-    ],
+    "types": ["Psychic"],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729322390/starsuho_altair_starry%20night_suho.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725518688/card_foil_mihi_hextile.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "anexxm",
@@ -2540,11 +2817,11 @@
     "cardGroup": "Anniversary",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319010/anexxm_altair_anniversary_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729319010/anexxm_altair_anniversary_xiumin.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "12yrsxm",
@@ -2552,71 +2829,83 @@
     "cardGroup": "EXO Day",
     "name": "Xiumin",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Rare Holo VSTAR",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318409/12yrsxm_altair_anniversary_xiumin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729318409/12yrsxm_altair_anniversary_xiumin.png",
+    "category": "Event",
+    "keyword": "12 Years"
   },
   {
     "id": "ocbbh",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Baekhyun",
     "group": "EXO",
     "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159258/ocbbh_ordinary_cbx_baekhyun_kmm79b.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159258/ocbbh_ordinary_cbx_baekhyun_kmm79b.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "ocbcn",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Chen",
     "group": "EXO",
     "types": ["Grass"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159253/ocbcn_ordinary_cbx_chen_xliyna.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159253/ocbcn_ordinary_cbx_chen_xliyna.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "ocbxm",
     "cardRarity": "Ordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Xiumin",
     "group": "EXO",
     "types": ["Fairy"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159264/ocbxm_ordinary_cbx_xiumin_kyhskk.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159264/ocbxm_ordinary_cbx_xiumin_kyhskk.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "ucbbh",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Baekhyun",
     "group": "EXO",
     "types": ["Fairy"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159274/ucbbh_unordinary_cbx_baekhyun_e2yf5x.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159274/ucbbh_unordinary_cbx_baekhyun_e2yf5x.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "ucbcn",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Chen",
     "group": "EXO",
     "types": ["Fairy"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159268/ucbcn_unordinary_cbx_chen_xhy9q5.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159268/ucbcn_unordinary_cbx_chen_xhy9q5.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "ucbxm",
     "cardRarity": "Unordinary",
-    "cardGroup": "EXO-CBX CBX",
+    "cardGroup": "EXO-CBX",
     "name": "Xiumin",
     "group": "EXO",
     "types": ["Water"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159278/ucbxm_unordinary_cbx_xiumin_bxwt5p.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728159278/ucbxm_unordinary_cbx_xiumin_bxwt5p.png",
+    "category": "Regular",
+    "keyword": "CBX"
   },
   {
     "id": "oescy",
@@ -2624,11 +2913,11 @@
     "cardGroup": "EXO-SC",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158519/oescy_ordinary_sc_chanyeol_spjas6.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158519/oescy_ordinary_sc_chanyeol_spjas6.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "oessh",
@@ -2636,11 +2925,11 @@
     "cardGroup": "EXO-SC",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Darkness"
-    ],
+    "types": ["Darkness"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158528/oessh_ordinary_sc_sehun_hy0uzc.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158528/oessh_ordinary_sc_sehun_hy0uzc.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "uescy",
@@ -2648,11 +2937,11 @@
     "cardGroup": "EXO-SC",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fairy"
-    ],
+    "types": ["Fairy"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158575/uescy_unordinary_sc_chanyeol_vzv3re.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158575/uescy_unordinary_sc_chanyeol_vzv3re.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "uessh",
@@ -2660,11 +2949,11 @@
     "cardGroup": "EXO-SC",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158580/uessh_unordinary_sc_sehun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158580/uessh_unordinary_sc_sehun.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "rescy",
@@ -2672,11 +2961,11 @@
     "cardGroup": "EXO-SC",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158663/rescy_rare_sc_chanyeol_mebup7.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158663/rescy_rare_sc_chanyeol_mebup7.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "ressh",
@@ -2684,11 +2973,11 @@
     "cardGroup": "EXO-SC",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Water"
-    ],
+    "types": ["Water"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158667/ressh_rare_sc_sehun_j0bndh.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158667/ressh_rare_sc_sehun_j0bndh.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "sescy",
@@ -2696,11 +2985,11 @@
     "cardGroup": "EXO-SC",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158738/sescy_special_sc_chanyeol_ww1f5y.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158738/sescy_special_sc_chanyeol_ww1f5y.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "sessh",
@@ -2708,11 +2997,11 @@
     "cardGroup": "EXO-SC",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Lightning"
-    ],
+    "types": ["Lightning"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158743/sessh_special_sc_sehun_hnyb8z.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158743/sessh_special_sc_sehun_hnyb8z.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "eescy",
@@ -2720,11 +3009,11 @@
     "cardGroup": "EXO-SC",
     "name": "Chanyeol",
     "group": "EXO",
-    "types": [
-      "Fire"
-    ],
+    "types": ["Fire"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158785/eescy_extraordinary_sc_chanyeol_eje3y0.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158785/eescy_extraordinary_sc_chanyeol_eje3y0.png",
+    "category": "Regular",
+    "keyword": "SC"
   },
   {
     "id": "eessh",
@@ -2732,10 +3021,10 @@
     "cardGroup": "EXO-SC",
     "name": "Sehun",
     "group": "EXO",
-    "types": [
-      "Metal"
-    ],
+    "types": ["Metal"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158788/eessh_extraordinary_sc_sehun_tbdhjs.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728158788/eessh_extraordinary_sc_sehun_tbdhjs.png",
+    "category": "Regular",
+    "keyword": "SC"
   }
 ]

--- a/src/lib/database/nctLibrary.json
+++ b/src/lib/database/nctLibrary.json
@@ -2,1852 +2,2842 @@
   {
     "id": "oncdy",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/oncdy_ordinary_nct127_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/oncdy_ordinary_nct127_doyoung.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "onchc",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215794/onchc_ordinary_nct127_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215794/onchc_ordinary_nct127_haechan.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "oncjh",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215826/oncjh_ordinary_nct127_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215826/oncjh_ordinary_nct127_jaehyun.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "oncjn",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215797/oncjn_ordinary_nct127_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215797/oncjn_ordinary_nct127_johnny.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "oncjw",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215801/oncjw_ordinary_nct127_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215801/oncjw_ordinary_nct127_jungwoo.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "oncmk",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215803/oncmk_ordinary_nct127_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215803/oncmk_ordinary_nct127_mark.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "oncty",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215806/oncty_ordinary_nct127_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215806/oncty_ordinary_nct127_taeyong.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "oncyt",
     "cardRarity": "Ordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/oncyt_ordinary_nct127_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/oncyt_ordinary_nct127_yuta.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "uncdy",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215841/uncdy_unordinary_nct127_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215841/uncdy_unordinary_nct127_doyoung.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "unchc",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215846/unchc_unordinary_nct127_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215846/unchc_unordinary_nct127_haechan.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "uncjh",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/uncjh_unordinary_nct127_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/uncjh_unordinary_nct127_jaehyun.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "uncjn",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215758/uncjn_unordinary_nct127_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215758/uncjn_unordinary_nct127_johnny.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "uncjw",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215753/uncjw_unordinary_nct127_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215753/uncjw_unordinary_nct127_jungwoo.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "uncmk",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215778/uncmk_unordinary_nct127_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215778/uncmk_unordinary_nct127_mark.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "uncty",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/uncty_unordinary_nct127_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215791/uncty_unordinary_nct127_taeyong.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "uncyt",
     "cardRarity": "Unordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215765/uncyt_unordinary_nct127_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215765/uncyt_unordinary_nct127_yuta.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rncdy",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215813/rncdy_rare_nct127_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215813/rncdy_rare_nct127_doyoung.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rnchc",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215832/rnchc_rare_nct127_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215832/rnchc_rare_nct127_haechan.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "rncjh",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215818/rncjh_rare_nct127_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215818/rncjh_rare_nct127_jaehyun.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rncjn",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/rncjn_rare_nct127_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/rncjn_rare_nct127_johnny.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rncjw",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215840/rncjw_rare_nct127_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215840/rncjw_rare_nct127_jungwoo.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rncmk",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/rncmk_rare_nct127_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/rncmk_rare_nct127_mark.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "rncty",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215843/rncty_rare_nct127_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215843/rncty_rare_nct127_taeyong.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "rncyt",
     "cardRarity": "Rare",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215842/rncyt_rare_nct127_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215842/rncyt_rare_nct127_yuta.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "sncdy",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215773/sncdy_special_nct127_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215773/sncdy_special_nct127_doyoung.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "snchc",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215766/snchc_special_nct127_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215766/snchc_special_nct127_haechan.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "sncjh",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215751/sncjh_special_nct127_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215751/sncjh_special_nct127_jaehyun.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "sncjn",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215777/sncjn_special_nct127_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215777/sncjn_special_nct127_johnny.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "sncjw",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215769/sncjw_special_nct127_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215769/sncjw_special_nct127_jungwoo.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "sncmk",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215762/sncmk_special_nct127_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215762/sncmk_special_nct127_mark.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "sncty",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215759/sncty_special_nct127_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215759/sncty_special_nct127_taeyong.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "sncyt",
     "cardRarity": "Special",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/sncyt_special_nct127_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215845/sncyt_special_nct127_yuta.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "encdy",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/encdy_extraordinary_nct127_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215810/encdy_extraordinary_nct127_doyoung.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "enchc",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215772/enchc_extraordinary_nct127_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215772/enchc_extraordinary_nct127_haechan.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "encjh",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/encjh_extraordinary_nct127_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215822/encjh_extraordinary_nct127_jaehyun.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "encjn",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215779/encjn_extraordinary_nct127_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215779/encjn_extraordinary_nct127_johnny.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "encjw",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215820/encjw_extraordinary_nct127_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215820/encjw_extraordinary_nct127_jungwoo.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "encmk",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/encmk_extraordinary_nct127_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215831/encmk_extraordinary_nct127_mark.png",
+    "category": "Regular",
+    "keyword": "Dream 127"
   },
   {
     "id": "encty",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215783/encty_extraordinary_nct127_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215783/encty_extraordinary_nct127_taeyong.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "encyt",
     "cardRarity": "Extraordinary",
-    "cardGroup": "NCT127 127",
+    "cardGroup": "NCT127",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215788/encyt_extraordinary_nct127_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728215788/encyt_extraordinary_nct127_yuta.png",
+    "category": "Regular",
+    "keyword": " 127"
   },
   {
     "id": "ondch",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/ondch_ordinary_nct%20dream_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/ondch_ordinary_nct%20dream_chenle.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ondhc",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164311/ondhc_ordinary_nct%20dream_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164311/ondhc_ordinary_nct%20dream_haechan.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "ondjm",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjm_ordinary_nct%20dream_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjm_ordinary_nct%20dream_jaemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ondjn",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjn_ordinary_nct%20dream_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/ondjn_ordinary_nct%20dream_jeno.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ondjs",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164318/ondjs_ordinary_nct%20dream_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164318/ondjs_ordinary_nct%20dream_jisung.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ondmk",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164326/ondmk_ordinary_nct%20dream_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164326/ondmk_ordinary_nct%20dream_mark.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "ondrj",
     "cardRarity": "Ordinary",
     "cardGroup": "NCT Dream",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164325/ondrj_ordinary_nct%20dream_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164325/ondrj_ordinary_nct%20dream_renjun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "undch",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undch_unordinary_nct%20dream_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undch_unordinary_nct%20dream_chenle.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "undhc",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undhc_unordinary_nct%20dream_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164353/undhc_unordinary_nct%20dream_haechan.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "undjm",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164354/undjm_unordinary_nct%20dream_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164354/undjm_unordinary_nct%20dream_jaemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "undjn",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjn_unordinary_nct%20dream_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjn_unordinary_nct%20dream_jeno.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "undjs",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjs_unordinary_nct%20dream_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164361/undjs_unordinary_nct%20dream_jisung.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "undmk",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164360/undmk_unordinary_nct%20dream_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164360/undmk_unordinary_nct%20dream_mark.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "undrj",
     "cardRarity": "Unordinary",
     "cardGroup": "NCT Dream",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164374/undrj_unordinary_nct%20dream_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164374/undrj_unordinary_nct%20dream_renjun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rndch",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164327/rndch_rare_nct%20dream_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164327/rndch_rare_nct%20dream_chenle.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rndhc",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164341/rndhc_rare_nct%20dream_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164341/rndhc_rare_nct%20dream_haechan.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "rndjm",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164344/rndjm_rare_nct%20dream_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164344/rndjm_rare_nct%20dream_jaemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rndjn",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164345/rndjn_rare_nct%20dream_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164345/rndjn_rare_nct%20dream_jeno.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rndjs",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164348/rndjs_rare_nct%20dream_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164348/rndjs_rare_nct%20dream_jisung.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rndmk",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/rndmk_rare_nct%20dream_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164315/rndmk_rare_nct%20dream_mark.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "rndrj",
     "cardRarity": "Rare",
     "cardGroup": "NCT Dream",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164320/rndrj_rare_nct%20dream_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164320/rndrj_rare_nct%20dream_renjun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sndch",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndch_special_nct%20dream_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndch_special_nct%20dream_chenle.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sndhc",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164387/sndhc_special_nct%20dream_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164387/sndhc_special_nct%20dream_haechan.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "sndjm",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164389/sndjm_special_nct%20dream_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164389/sndjm_special_nct%20dream_jaemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sndjn",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndjn_special_nct%20dream_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndjn_special_nct%20dream_jeno.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sndjs",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndjs_special_nct%20dream_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164334/sndjs_special_nct%20dream_jisung.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "sndmk",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndmk_special_nct%20dream_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164390/sndmk_special_nct%20dream_mark.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "sndrj",
     "cardRarity": "Special",
     "cardGroup": "NCT Dream",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/sndrj_special_nct%20dream_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164302/sndrj_special_nct%20dream_renjun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "endch",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164367/endch_extraordinary_nct%20dream_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164367/endch_extraordinary_nct%20dream_chenle.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "endhc",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164371/endhc_extraordinary_nct%20dream_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164371/endhc_extraordinary_nct%20dream_haechan.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "endjm",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164329/endjm_extraordinary_nct%20dream_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164329/endjm_extraordinary_nct%20dream_jaemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "endjn",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164391/endjn_extraordinary_nct%20dream_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164391/endjn_extraordinary_nct%20dream_jeno.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "endjs",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164381/endjs_extraordinary_nct%20dream_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164381/endjs_extraordinary_nct%20dream_jisung.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "endmk",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164377/endmk_extraordinary_nct%20dream_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164377/endmk_extraordinary_nct%20dream_mark.png",
+    "category": "Regular",
+    "keyword": " NCT127 127"
   },
   {
     "id": "endrj",
     "cardRarity": "Extraordinary",
     "cardGroup": "NCT Dream",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164376/endrj_extraordinary_nct%20dream_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728164376/endrj_extraordinary_nct%20dream_renjun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvhd",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980665/owvhd_ordinary_wayv_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980665/owvhd_ordinary_wayv_hendery.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvkn",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvkn_ordinary_wayv_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvkn_ordinary_wayv_kun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvtn",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvtn_ordinary_wayv_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/owvtn_ordinary_wayv_ten.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvww",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Fighting"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980634/owvww_ordinary_wayv_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980634/owvww_ordinary_wayv_winwin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvxj",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980638/owvxj_ordinary_wayv_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980638/owvxj_ordinary_wayv_xiaojun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "owvyy",
     "cardRarity": "Ordinary",
     "cardGroup": "WayV",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980637/owvyy_ordinary_wayv_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980637/owvyy_ordinary_wayv_yangyang.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvhd",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/uwvhd_unordinary_wayv_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/uwvhd_unordinary_wayv_hendery.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvkn",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980669/uwvkn_unordinary_wayv_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980669/uwvkn_unordinary_wayv_kun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvtn",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980671/uwvtn_unordinary_wayv_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980671/uwvtn_unordinary_wayv_ten.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvww",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Fire"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980675/uwvww_unordinary_wayv_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980675/uwvww_unordinary_wayv_winwin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvxj",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980658/uwvxj_unordinary_wayv_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980658/uwvxj_unordinary_wayv_xiaojun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "uwvyy",
     "cardRarity": "Unordinary",
     "cardGroup": "WayV",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/uwvyy_unordinary_wayv_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/uwvyy_unordinary_wayv_yangyang.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvhd",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvhd_rare_wayv_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvhd_rare_wayv_hendery.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvkn",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvkn_rare_wayv_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvkn_rare_wayv_kun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvtn",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980644/rwvtn_rare_wayv_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980644/rwvtn_rare_wayv_ten.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvww",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Darkness"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/rwvww_rare_wayv_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980650/rwvww_rare_wayv_winwin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvxj",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvxj_rare_wayv_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980641/rwvxj_rare_wayv_xiaojun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rwvyy",
     "cardRarity": "Rare",
     "cardGroup": "WayV",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980647/rwvyy_rare_wayv_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980647/rwvyy_rare_wayv_yangyang.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvhd",
     "cardRarity": "Special",
     "cardGroup": "WayV",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvhd_special_wayv_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvhd_special_wayv_hendery.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvkn",
     "cardRarity": "Special",
     "cardGroup": "WayV",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980674/swvkn_special_wayv_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980674/swvkn_special_wayv_kun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvtn",
     "cardRarity": "Special",
     "cardGroup": "WayV",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvtn_special_wayv_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/swvtn_special_wayv_ten.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvww",
     "cardRarity": "Special",
     "cardGroup": "WayV",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Lightning"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980653/swvww_special_wayv_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980653/swvww_special_wayv_winwin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvxj",
     "cardRarity": "Special",
     "cardGroup": "WayV",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvxj_special_wayv_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvxj_special_wayv_xiaojun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "swvyy",
     "cardRarity": "Special",
     "cardGroup": "WayV",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvyy_special_wayv_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980654/swvyy_special_wayv_yangyang.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvhd",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980656/ewvhd_extraordinary_wayv_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980656/ewvhd_extraordinary_wayv_hendery.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvkn",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980645/ewvkn_extraordinary_wayv_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980645/ewvkn_extraordinary_wayv_kun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvtn",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980661/ewvtn_extraordinary_wayv_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980661/ewvtn_extraordinary_wayv_ten.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvww",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Metal"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980646/ewvww_extraordinary_wayv_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980646/ewvww_extraordinary_wayv_winwin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvxj",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/ewvxj_extraordinary_wayv_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980666/ewvxj_extraordinary_wayv_xiaojun.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ewvyy",
     "cardRarity": "Extraordinary",
     "cardGroup": "WayV",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/ewvyy_extraordinary_wayv_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728980660/ewvyy_extraordinary_wayv_yangyang.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ukxkn",
     "cardRarity": "Ordinary",
     "cardGroup": "KUN&XIAOJUN",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984903/ukxkn_ordinary_kun-xiaojun_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984903/ukxkn_ordinary_kun-xiaojun_kun.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "okxkn",
     "cardRarity": "Ordinary",
     "cardGroup": "KUN&XIAOJUN",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984892/okxkn_ordinary_kun-xiaojun_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984892/okxkn_ordinary_kun-xiaojun_kun.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "ukxxj",
     "cardRarity": "Ordinary",
     "cardGroup": "KUN&XIAOJUN",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984909/ukxxj_ordinary_kun-xiaojun_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984909/ukxxj_ordinary_kun-xiaojun_xiaojun.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "okxxj",
     "cardRarity": "Ordinary",
     "cardGroup": "KUN&XIAOJUN",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984896/okxxj_ordinary_kun-xiaojun_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728984896/okxxj_ordinary_kun-xiaojun_xiaojun.png",
+    "category": "Regular",
+    "keyword": "WayV"
+  },
+  {
+    "id": "onwjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/onwjh_ordinary_nct%20wish_jaehee.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "onwrk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwrk_ordinary_nct%20wish_riku.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "onwry",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700928/onwry_ordinary_nct%20wish_ryo.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "onwsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/onwsk_ordinary_nct%20wish_sakuya.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "onwsn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700943/onwsn_ordinary_nct%20wish_sion.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "onwys",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwys_ordinary_nct%20wish_yushi.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwjh_unordinary_nct%20wish_jaehee.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwrk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwrk_unordinary_nct%20wish_riku.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwry",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700935/unwry_unordinary_nct%20wish_ryo.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700923/unwsk_unordinary_nct%20wish_sakuya.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwsn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwsn_unordinary_nct%20wish_sion.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "unwys",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwys_unordinary_nct%20wish_yushi.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwjh",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/rnwjh_rare_nct%20wish_jaehee.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwrk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700934/rnwrk_rare_nct%20wish_riku.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwry",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700942/rnwry_rare_nct%20wish_ryo.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwsk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700948/rnwsk_rare_nct%20wish_sakuya.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwsn",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700919/rnwsn_rare_nct%20wish_sion.png",
+    "category": "Regular",
+    "keyword": ""
+  },
+  {
+    "id": "rnwys",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/rnwys_rare_nct%20wish_yushi.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "osljh",
     "cardRarity": "Ordinary",
     "cardGroup": "Soloist",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221939/osljh_ordinary_soloist_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221939/osljh_ordinary_soloist_jaehyun.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "oslmk",
     "cardRarity": "Ordinary",
     "cardGroup": "Soloist",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221955/oslmk_ordinary_soloist_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221955/oslmk_ordinary_soloist_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "oslty",
     "cardRarity": "Ordinary",
     "cardGroup": "Soloist",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221751/oslty_ordinary_soloist_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221751/oslty_ordinary_soloist_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "osltn",
     "cardRarity": "Ordinary",
     "cardGroup": "Soloist",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221968/osltn_ordinary_soloist_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221968/osltn_ordinary_soloist_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "usljh",
     "cardRarity": "Unordinary",
     "cardGroup": "Soloist",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222076/usljh_unordinary_soloist_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222076/usljh_unordinary_soloist_jaehyun.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "uslmk",
     "cardRarity": "Unordinary",
     "cardGroup": "Soloist",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222098/uslmk_unordinary_soloist_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222098/uslmk_unordinary_soloist_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "uslty",
     "cardRarity": "Unordinary",
     "cardGroup": "Soloist",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221884/uslty_unordinary_soloist_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221884/uslty_unordinary_soloist_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "usltn",
     "cardRarity": "Unordinary",
     "cardGroup": "Soloist",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221748/usltn_unordinary_soloist_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221748/usltn_unordinary_soloist_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "rsljh",
     "cardRarity": "Rare",
     "cardGroup": "Soloist",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221981/rsljh_rare_soloist_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221981/rsljh_rare_soloist_jaehyun.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "rslmk",
     "cardRarity": "Rare",
     "cardGroup": "Soloist",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221999/rslmk_rare_soloist_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221999/rslmk_rare_soloist_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "rslty",
     "cardRarity": "Rare",
     "cardGroup": "Soloist",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221867/rslty_rare_soloist_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221867/rslty_rare_soloist_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "rsltn",
     "cardRarity": "Rare",
     "cardGroup": "Soloist",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222016/rsltn_rare_soloist_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222016/rsltn_rare_soloist_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "ssljh",
     "cardRarity": "Special",
     "cardGroup": "Soloist",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222034/ssljh_special_soloist_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222034/ssljh_special_soloist_jaehyun.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "sslmk",
     "cardRarity": "Special",
     "cardGroup": "Soloist",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222048/sslmk_special_soloist_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222048/sslmk_special_soloist_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "sslty",
     "cardRarity": "Special",
     "cardGroup": "Soloist",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221877/sslty_special_soloist_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221877/sslty_special_soloist_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "ssltn",
     "cardRarity": "Special",
     "cardGroup": "Soloist",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222062/ssltn_special_soloist_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728222062/ssltn_special_soloist_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "esljh",
     "cardRarity": "Extraordinary",
     "cardGroup": "Soloist",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221893/esljh_extraordinary_soloist_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221893/esljh_extraordinary_soloist_jaehyun.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "eslmk",
     "cardRarity": "Extraordinary",
     "cardGroup": "Soloist",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221904/eslmk_extraordinary_soloist_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221904/eslmk_extraordinary_soloist_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "eslty",
     "cardRarity": "Extraordinary",
     "cardGroup": "Soloist",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221925/eslty_extraordinary_soloist_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221925/eslty_extraordinary_soloist_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "esltn",
     "cardRarity": "Extraordinary",
     "cardGroup": "Soloist",
-    "name": "Ten WayV",
+    "name": "Ten",
     "group": "NCT",
-    "types": ["Metal"],
+    "types": [
+      "Metal"
+    ],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221915/esltn_extraordinary_soloist_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728221915/esltn_extraordinary_soloist_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "sfmyve",
     "cardRarity": "Priceless",
-    "cardGroup": "Staffmate Event",
+    "cardGroup": "Staffmate",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/sfmyve_priceless_staffmate_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/sfmyve_priceless_staffmate_yuta.png",
+    "category": "Event",
+    "keyword": "NCT127 127 Staff Mate"
   },
   {
     "id": "scoyut",
     "cardRarity": "Priceless",
     "cardGroup": "Scorpio",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/scoyut_priceless_scorpio_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/scoyut_priceless_scorpio_yuta.png",
+    "category": "Event",
+    "keyword": "Zodiac NCT127 127"
   },
   {
     "id": "amejae",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/amejae_priceless_amethyst_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/amejae_priceless_amethyst_jaehyun.png",
+    "category": "Gemstone",
+    "keyword": "Event NCT127 127"
   },
   {
     "id": "ubyong",
     "cardRarity": "Priceless",
     "cardGroup": "Ruby",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/ubyong_priceless_ruby_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990219/ubyong_priceless_ruby_taeyong.png",
+    "category": "Gemstone",
+    "keyword": "Event NCT127 127"
   },
   {
     "id": "sarryo",
     "cardRarity": "Priceless",
     "cardGroup": "Sardonyx",
     "name": "Ryo",
-    "group": "NCT WISH",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990218/sarryo_priceless_sardonyx_ryo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990218/sarryo_priceless_sardonyx_ryo.png",
+    "category": "Gemstone",
+    "keyword": "Event WISH"
   },
   {
     "id": "emesio",
     "cardRarity": "Priceless",
     "cardGroup": "Emerald",
     "name": "Sion",
-    "group": "NCT WISH",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990213/emesio_priceless_emerald_sion.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990213/emesio_priceless_emerald_sion.png",
+    "category": "Gemstone",
+    "keyword": "Event WISH"
   },
   {
     "id": "slmjae",
     "cardRarity": "Priceless",
-    "cardGroup": "Soulmate Event",
+    "cardGroup": "Soulmate",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990212/slmjae_priceless_soulmate_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990212/slmjae_priceless_soulmate_jaehyun.png",
+    "category": "Event",
+    "keyword": "NCT127 127 Soul Mate"
   },
   {
     "id": "libion",
     "cardRarity": "Priceless",
     "cardGroup": "Libra",
     "name": "Sion",
-    "group": "NCT WISH",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/libion_priceless_libra_sion.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/libion_priceless_libra_sion.png",
+    "category": "Event",
+    "keyword": "Zodiac WISH"
   },
   {
     "id": "cantae",
     "cardRarity": "Priceless",
     "cardGroup": "Cancer",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/cantae_priceless_cancer_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990210/cantae_priceless_cancer_taeyong.png",
+    "category": "Event",
+    "keyword": "Zodiac NCT127 127"
   },
   {
     "id": "btaiku",
     "cardRarity": "Priceless",
     "cardGroup": "BTA",
     "name": "Riku",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/btaiku_priceless_bta_riku.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/btaiku_priceless_bta_riku.png",
+    "category": "Event",
+    "keyword": "WISH"
   },
   {
     "id": "apodoy",
     "cardRarity": "Priceless",
-    "cardGroup": "Apocalypse Event",
+    "cardGroup": "Apocalypse",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/apodoy_priceless_apocalypse_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990209/apodoy_priceless_apocalypse_doyoung.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "apfjoh",
     "cardRarity": "Priceless",
-    "cardGroup": "April Fools Event Apf",
+    "cardGroup": "Apf",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/apfjoh_priceless_apf_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/apfjoh_priceless_apf_johnny.png",
+    "category": "Event",
+    "keyword": "NCT127 127 April Fools"
   },
   {
     "id": "amedoy",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/amedoy_priceless_amethyst_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990202/amedoy_priceless_amethyst_doyoung.png",
+    "category": "Gemstone",
+    "keyword": "Event NCT127 127"
   },
   {
     "id": "apfdoy",
     "cardRarity": "Priceless",
-    "cardGroup": "April Fools Event Bapf",
+    "cardGroup": "Bapf",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/apfdoy_priceless_apd_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/apfdoy_priceless_apd_doyoung.png",
+    "category": "Event",
+    "keyword": "NCT127 127 April Fools"
   },
   {
     "id": "amejoh",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/amejoh_priceless_amethyst_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990201/amejoh_priceless_amethyst_johnny.png",
+    "category": "Gemstone",
+    "keyword": "Event NCT127 127"
   },
   {
     "id": "amewoo",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990200/amewoo_priceless_amethyst_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990200/amewoo_priceless_amethyst_jungwoo.png",
+    "category": "Gemstone",
+    "keyword": "Event NCT127 127"
   },
   {
     "id": "alejae",
     "cardRarity": "Priceless",
     "cardGroup": "Alexandrite",
     "name": "Jaehee",
-    "group": "NCT WISH",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/alejae_priceless_alexandrite_jaehee.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/alejae_priceless_alexandrite_jaehee.png",
+    "category": "Gemstone",
+    "keyword": "Event WISH"
   },
   {
     "id": "sumren",
     "cardRarity": "Priceless",
-    "cardGroup": "Summer Event",
+    "cardGroup": "Psummer",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/sumren_priceless_summer_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990196/sumren_priceless_summer_renjun.png",
+    "category": "Event",
+    "keyword": "Dream Summer"
   },
   {
     "id": "xm127",
     "cardRarity": "Priceless",
-    "cardGroup": "Xmas Xmas23",
-    "name": "NCT127 127 group",
-    "group": "NCT NCT127 127",
-    "types": ["Fighting"],
+    "cardGroup": "Pxmas23",
+    "name": "NCT127",
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/xm127_priceless_xmas23_nct_127.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/xm127_priceless_xmas23_nct_127.png",
+    "category": "Event",
+    "keyword": "127 Group Xmas Christmas"
   },
   {
     "id": "sroark",
     "cardRarity": "Priceless",
     "cardGroup": "Sanrio",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/sroark_priceless_sanrio_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990191/sroark_priceless_sanrio_mark.png",
+    "category": "Event",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "roykun",
     "cardRarity": "Priceless",
     "cardGroup": "Royal Event",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/roykun_priceless_royal%20event_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/roykun_priceless_royal%20event_kun.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "sfmwni",
     "cardRarity": "Priceless",
-    "cardGroup": "Staffmate Event",
+    "cardGroup": "Staffmate",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/sfmwni_priceless_staffmate_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990190/sfmwni_priceless_staffmate_renjun.png",
+    "category": "Event",
+    "keyword": "Dream Staff Mate"
   },
   {
     "id": "sarark",
     "cardRarity": "Priceless",
     "cardGroup": "Sardonyx",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990187/sarark_priceless_sardonyx_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990187/sarark_priceless_sardonyx_mark.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream NCT127 127"
   },
   {
     "id": "leomar",
     "cardRarity": "Priceless",
     "cardGroup": "Leo",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/leomar_priceless_leo_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/leomar_priceless_leo_mark.png",
+    "category": "Event",
+    "keyword": "Zodiac Dream NCT127 127"
   },
   {
     "id": "sarjae",
     "cardRarity": "Priceless",
     "cardGroup": "Sardonyx",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/sarjae_priceless_sardonyx_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990185/sarjae_priceless_sardonyx_jaemin.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream"
   },
   {
     "id": "leomin",
     "cardRarity": "Priceless",
     "cardGroup": "Leo",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990182/leomin_priceless_leo_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990182/leomin_priceless_leo_jaemin.png",
+    "category": "Event",
+    "keyword": "Zodiac Dream"
   },
   {
     "id": "zuhjno",
     "cardRarity": "Priceless",
-    "cardGroup": "Cardcaptor",
+    "cardGroup": "Bcardcaptor",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990181/zuhjno_priceless_cardcaptor_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990181/zuhjno_priceless_cardcaptor_jeno.png",
+    "category": "Event",
+    "keyword": "Dream Cardcaptor Card Captor"
   },
   {
     "id": "sagche",
     "cardRarity": "Priceless",
     "cardGroup": "Sagittarius",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990178/sagche_priceless_sagittarius_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990178/sagche_priceless_sagittarius_chenle.png",
+    "category": "Event",
+    "keyword": "Zodiac Dream"
   },
   {
     "id": "pseyt",
     "cardRarity": "Priceless",
     "cardGroup": "Stardust Event",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990177/pseyt_priceless_stardust_event_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990177/pseyt_priceless_stardust_event_yuta.png",
+    "category": "Event",
+    "keyword": "NCT127 127 Star Dust"
   },
   {
     "id": "hbdrhi",
     "cardRarity": "Priceless",
     "cardGroup": "Staff Birthday",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990176/hbdrhi_priceless_staff%20birthday_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990176/hbdrhi_priceless_staff%20birthday_jisung.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "fmxmcl",
     "cardRarity": "Priceless",
     "cardGroup": "Fanmade Xmas",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990172/fmxmcl_priceless_fanmade%20xmas_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990172/fmxmcl_priceless_fanmade%20xmas_chenle.png",
+    "category": "Event",
+    "keyword": "Dream Christmas"
   },
   {
     "id": "evhaec",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Pevil",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/evhaec_priceless_evil_haechan.gif"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/evhaec_priceless_evil_haechan.gif",
+    "category": "Event",
+    "keyword": "Dream NCT127 127 Evil"
   },
   {
     "id": "faejsg",
     "cardRarity": "Priceless",
-    "cardGroup": "Fairy Fairies Event",
+    "cardGroup": "Bfairies",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990170/faejsg_priceless_fairies_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990170/faejsg_priceless_fairies_jisung.png",
+    "category": "Event",
+    "keyword": "Dream Fairy Fairies"
   },
   {
     "id": "diajen",
     "cardRarity": "Priceless",
     "cardGroup": "Diamond",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/diajen_priceless_diamond_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990169/diajen_priceless_diamond_jeno.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream"
   },
   {
     "id": "btahae",
     "cardRarity": "Priceless",
     "cardGroup": "BTA",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990168/btahae_priceless_bta_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990168/btahae_priceless_bta_haechan.png",
+    "category": "Event",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "cdycnl",
     "cardRarity": "Priceless",
-    "cardGroup": "Candy Event",
+    "cardGroup": "Candy",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990166/cdycnl_priceless_candy_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990166/cdycnl_priceless_candy_chenle.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "amejis",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990163/amejis_priceless_amethyst_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990163/amejis_priceless_amethyst_jisung.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream"
   },
   {
     "id": "alehae",
     "cardRarity": "Priceless",
     "cardGroup": "Alexandrite",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990162/alehae_priceless_alexandrite_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990162/alehae_priceless_alexandrite_haechan.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream NCT127 127"
   },
   {
     "id": "apfjmn",
     "cardRarity": "Priceless",
-    "cardGroup": "April Fools Event Papf",
+    "cardGroup": "Papf",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/apfjmn_priceless_apf_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/apfjmn_priceless_apf_jaemin.png",
+    "category": "Event",
+    "keyword": "Dream April Fools"
   },
   {
     "id": "xowin",
     "cardRarity": "Priceless",
-    "cardGroup": "XOXO Event",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Fairy"],
+    "cardGroup": "XOXO",
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/xowin_priceless_xoxo_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990160/xowin_priceless_xoxo_winwin.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "tyuten",
     "cardRarity": "Priceless",
-    "cardGroup": "Thanku",
+    "cardGroup": "Bthanku",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990158/tyuten_priceless_thanku_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990158/tyuten_priceless_thanku_ten.png",
+    "category": "Event",
+    "keyword": "WayV Thank You"
   },
   {
     "id": "sumwin",
     "cardRarity": "Priceless",
-    "cardGroup": "Summer",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Water"],
+    "cardGroup": "Bsummer",
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990153/sumwin_priceless_summer_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990153/sumwin_priceless_summer_winwin.png",
+    "category": "Event",
+    "keyword": "WayV Summer"
   },
   {
     "id": "sarjun",
     "cardRarity": "Priceless",
     "cardGroup": "Sardonyx",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Fighting"],
+    "group": "NCT",
+    "types": [
+      "Fighting"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sarjun_priceless_sardonyx_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sarjun_priceless_sardonyx_xiaojun.png",
+    "category": "Gemstone",
+    "keyword": "Event WayV"
   },
   {
     "id": "sapder",
     "cardRarity": "Priceless",
     "cardGroup": "Sapphire",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sapder_priceless_sapphire_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990152/sapder_priceless_sapphire_hendery.png",
+    "category": "Gemstone",
+    "keyword": "Event WayV"
   },
   {
     "id": "sroery",
     "cardRarity": "Priceless",
-    "cardGroup": "Sanrio",
+    "cardGroup": "Bsanrio",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990151/sroery_priceless_sanrio_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990151/sroery_priceless_sanrio_hendery.png",
+    "category": "Event",
+    "keyword": "WayV Sanrio"
   },
   {
     "id": "scowin",
     "cardRarity": "Priceless",
     "cardGroup": "Scorpio",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Fire"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990149/scowin_priceless_scorpio_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990149/scowin_priceless_scorpio_winwin.png",
+    "category": "Event",
+    "keyword": "Zodiac WayV"
   },
   {
     "id": "pserj",
     "cardRarity": "Priceless",
     "cardGroup": "Stardust Event",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990147/pserj_priceless_stardust%20event_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990147/pserj_priceless_stardust%20event_renjun.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "paqxj",
     "cardRarity": "Priceless",
     "cardGroup": "Aphrodite",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990143/paqxj_priceless_aphrodite_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990143/paqxj_priceless_aphrodite_xiaojun.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "leojun",
     "cardRarity": "Priceless",
     "cardGroup": "Leo",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990141/leojun_priceless_leo_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990141/leojun_priceless_leo_xiaojun.png",
+    "category": "Event",
+    "keyword": "Zodiac WayV"
   },
   {
     "id": "evtenn",
     "cardRarity": "Priceless",
-    "cardGroup": "Evil Event",
+    "cardGroup": "Evil",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/evtenn_priceless_evil_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/evtenn_priceless_evil_ten.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "libhen",
     "cardRarity": "Priceless",
     "cardGroup": "Libra",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/libhen_priceless_libra_hendery.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990140/libhen_priceless_libra_hendery.png",
+    "category": "Event",
+    "keyword": "Zodiac WayV"
   },
   {
     "id": "apokun",
     "cardRarity": "Priceless",
-    "cardGroup": "Apocalypse Event",
+    "cardGroup": "Apocalypse",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990137/apokun_priceless_apocalypse_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990137/apokun_priceless_apocalypse_kun.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "faexia",
     "cardRarity": "Priceless",
-    "cardGroup": "Fairy Fairies Event",
+    "cardGroup": "Fairies",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990133/faexia_priceless_fairies_xiaojun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990133/faexia_priceless_fairies_xiaojun.png",
+    "category": "Event",
+    "keyword": "WayV Fairy"
   },
   {
     "id": "apften",
     "cardRarity": "Priceless",
-    "cardGroup": "April Fools Event Papf",
+    "cardGroup": "Papf",
     "name": "Ten",
-    "group": "NCT WayV",
+    "group": "NCT",
     "types": "",
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/apften_priceless_apf_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/apften_priceless_apf_ten.png",
+    "category": "Event",
+    "keyword": "WayV April Fools"
   },
   {
     "id": "ameten",
     "cardRarity": "Priceless",
     "cardGroup": "Amethyst",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/ameten_priceless_amethyst_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990131/ameten_priceless_amethyst_ten.png",
+    "category": "Gemstone",
+    "keyword": "Event WayV"
   },
   {
     "id": "roydoy",
     "cardRarity": "Priceless",
     "cardGroup": "Royal Event",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Dragon"],
+    "group": "NCT",
+    "types": [
+      "Dragon"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990127/roydoy_priceless_royal%20event_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990127/roydoy_priceless_royal%20event_doyoung.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "hbdwonnie",
@@ -1855,322 +2845,446 @@
     "cardGroup": "Staff Birthday",
     "name": "NCT Dream group",
     "group": "NCT Dream",
-    "types": ["Fairy"],
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/hbdwonnie_priceless_staff%20birthday_nct%20dream.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/hbdwonnie_priceless_staff%20birthday_nct%20dream.png",
+    "category": "Event",
+    "keyword": ""
   },
   {
     "id": "xmyyg",
     "cardRarity": "Priceless",
-    "cardGroup": "Xmas Xmas23",
+    "cardGroup": "Xmas23",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/xmyyg_priceless_xmas23_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/xmyyg_priceless_xmas23_yangyang.png",
+    "category": "Event",
+    "keyword": "WayV Xmas Christmas"
   },
   {
     "id": "libyyg",
     "cardRarity": "Priceless",
     "cardGroup": "Libra",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990124/libyyg_priceless_libra_yangyang.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990124/libyyg_priceless_libra_yangyang.png",
+    "category": "Event",
+    "keyword": "Zodiac WayV"
   },
   {
     "id": "aquren",
     "cardRarity": "Priceless",
     "cardGroup": "Aquamarine",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990122/aquren_priceless_aquamarine_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990122/aquren_priceless_aquamarine_renjun.png",
+    "category": "Gemstone",
+    "keyword": "Event Dream"
   },
   {
     "id": "scosak",
     "cardRarity": "Priceless",
     "cardGroup": "Scorpio",
     "name": "Sakuya",
-    "group": "NCT WISH",
-    "types": ["Fire"],
+    "group": "NCT",
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990117/scosak_priceless_scorpio_sakuya.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990117/scosak_priceless_scorpio_sakuya.png",
+    "category": "Event",
+    "keyword": "Zodiac WISH"
   },
   {
     "id": "anwvww",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Metal"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985121/anwvww_altair_anniversary_winwin.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anwvtn",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985107/anwvtn_altair_anniversary_ten.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anwvkn",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985093/anwvkn_altair_anniversary_kun.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anwvhd",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Hendery",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985079/anwvhd_altair_anniversary_hendery.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anwvxj",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Xiaojun",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985068/anwvxj_altair_anniversary_xiaojun.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anwvyy",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Yangyang",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728985058/anwvyy_altair_anniversary_yangyang.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "anndrj",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Renjun",
-    "group": "NCT Dream",
-    "types": ["Psychic"],
+    "group": "NCT",
+    "types": [
+      "Psychic"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260295/anndrj_altair_anniversary_renjun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260295/anndrj_altair_anniversary_renjun.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "anndmk",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Water"],
+    "group": "NCT",
+    "types": [
+      "Water"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndmk_altair_anniversary_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndmk_altair_anniversary_mark.png",
+    "category": "Event",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "anndjn",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Jeno",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260299/anndjn_altair_anniversary_jeno.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260299/anndjn_altair_anniversary_jeno.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "anndhc",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Haechan",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndhc_altair_anniversary_haechan.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729260296/anndhc_altair_anniversary_haechan.png",
+    "category": "Event",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "anndjm",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Jaemin",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndjm_altair_anniversary_jaemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndjm_altair_anniversary_jaemin.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "anndcl",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndcl_altair_anniversary_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903140/anndcl_altair_anniversary_chenle.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "anndjs",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Jisung",
-    "group": "NCT Dream",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903137/anndjs_altair_anniversary_jisung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728903137/anndjs_altair_anniversary_jisung.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "dwjnmk",
     "cardRarity": "Altair",
-    "cardGroup": "Duoween",
+    "cardGroup": "DuoWeen",
     "name": "Johnny & Mark",
     "group": "NCT Dream NCT127 127",
-    "types": ["Fire"],
+    "types": [
+      "Fire"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728902100/dwjnmk_altair_duoween_johnny%20mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728902100/dwjnmk_altair_duoween_johnny%20mark.png",
+    "category": "Event",
+    "keyword": "Halloween"
   },
   {
     "id": "nwyrkn",
     "cardRarity": "Altair",
-    "cardGroup": "New Year",
+    "cardGroup": "NEW YEAR",
     "name": "Kun",
-    "group": "NCT WayV",
-    "types": ["Lightning"],
+    "group": "NCT",
+    "types": [
+      "Lightning"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901655/nwyrkn_altair_new%20year_kun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901655/nwyrkn_altair_new%20year_kun.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "lnywin",
     "cardRarity": "Altair",
     "cardGroup": "Lunar Year",
-    "name": "Winwin",
-    "group": "NCT WayV NCT127 127",
-    "types": ["Fairy"],
+    "name": "WinWin",
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901454/lnywin_altair_lunar%20year_winwin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901454/lnywin_altair_lunar%20year_winwin.png",
+    "category": "Event",
+    "keyword": "WayV"
   },
   {
     "id": "ftrsmmark",
     "cardRarity": "Altair",
     "cardGroup": "Futurism",
     "name": "Mark",
-    "group": "NCT Dream NCT127 127",
-    "types": ["Darkness"],
+    "group": "NCT",
+    "types": [
+      "Darkness"
+    ],
     "rarity": "Amazing Rare",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901210/ftrsmmark_altair_futurism_mark.png",
     "mask": "",
-    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png"
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213326/card_foil_v1.png",
+    "category": "Event",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "gmlchenle",
     "cardRarity": "Altair",
     "cardGroup": "Lucky",
     "name": "Chenle",
-    "group": "NCT Dream",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901047/gmlchenle_altair_lucky_chenle.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728901047/gmlchenle_altair_lucky_chenle.png",
+    "category": "Event",
+    "keyword": "Dream"
   },
   {
     "id": "foolten",
     "cardRarity": "Altair",
     "cardGroup": "Fools",
     "name": "Ten",
-    "group": "NCT WayV",
-    "types": ["Metal"],
+    "group": "NCT",
+    "types": [
+      "Metal"
+    ],
     "rarity": "Trainer Gallery Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900795/foolten_altair_fools_ten_in_wonderland.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900795/foolten_altair_fools_ten_in_wonderland.png",
+    "category": "Event",
+    "keyword": "WayV April"
   },
   {
     "id": "anncjn",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Johnny",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900496/anncjn_altair_anniversary_johnny.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900496/anncjn_altair_anniversary_johnny.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "anncty",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Taeyong",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900492/anncty_altair_anniversary_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900492/anncty_altair_anniversary_taeyong.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "anncyt",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncyt_altair_anniversary_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncyt_altair_anniversary_yuta.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "anncdy",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Doyoung",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncdy_altair_anniversary_doyoung.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900490/anncdy_altair_anniversary_doyoung.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "anncjw",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Jungwoo",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900489/anncjw_altair_anniversary_jungwoo.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900489/anncjw_altair_anniversary_jungwoo.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "anncjh",
     "cardRarity": "Altair",
     "cardGroup": "Anniversary",
     "name": "Jaehyun",
-    "group": "NCT NCT127 127",
-    "types": ["Fairy"],
+    "group": "NCT",
+    "types": [
+      "Fairy"
+    ],
     "rarity": "Rare Holo VMAX",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900487/anncjh_altair_anniversary_jaehyun.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728900487/anncjh_altair_anniversary_jaehyun.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   },
   {
     "id": "hbdyve",
     "cardRarity": "Priceless",
     "cardGroup": "Staff Birthday",
     "name": "Yuta",
-    "group": "NCT NCT127 127",
-    "types": ["Grass"],
+    "group": "NCT",
+    "types": [
+      "Grass"
+    ],
     "rarity": "Rare Shiny",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728725102/hbdyve_priceless_staff%20birthday_yuta.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728725102/hbdyve_priceless_staff%20birthday_yuta.png",
+    "category": "Event",
+    "keyword": "NCT127 127"
   }
 ]

--- a/src/lib/database/nctLibrary.json
+++ b/src/lib/database/nctLibrary.json
@@ -2843,15 +2843,15 @@
     "id": "hbdwonnie",
     "cardRarity": "Priceless",
     "cardGroup": "Staff Birthday",
-    "name": "NCT Dream group",
-    "group": "NCT Dream",
+    "name": "NCT Dream",
+    "group": "NCT",
     "types": [
       "Fairy"
     ],
     "rarity": "Rare Shiny",
     "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728990126/hbdwonnie_priceless_staff%20birthday_nct%20dream.png",
     "category": "Event",
-    "keyword": ""
+    "keyword": "group"
   },
   {
     "id": "xmyyg",

--- a/src/lib/database/superMLibrary.json
+++ b/src/lib/database/superMLibrary.json
@@ -5,9 +5,11 @@
     "cardGroup": "SuperM",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160135/osmbh_ordinary_superm_baekhyun_ajmxbe.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160135/osmbh_ordinary_superm_baekhyun_ajmxbe.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "osmka",
@@ -15,9 +17,11 @@
     "cardGroup": "SuperM",
     "name": "Kai",
     "group": "EXO",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160138/osmka_ordinary_superm_kai_df3fw4.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160138/osmka_ordinary_superm_kai_df3fw4.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "osmmk",
@@ -25,19 +29,23 @@
     "cardGroup": "SuperM",
     "name": "Mark",
     "group": "NCT",
-    "types": "",
+    "types": ["Fairy"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001535/osmmk_ordinary_superm_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001535/osmmk_ordinary_superm_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "osmtm",
     "cardRarity": "Ordinary",
     "cardGroup": "SuperM",
     "name": "Taemin",
-    "group": "Shinee",
-    "types": "",
+    "group": "SHINee",
+    "types": ["Water"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001550/osmtm_ordinary_superm_taemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001550/osmtm_ordinary_superm_taemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "osmtn",
@@ -45,9 +53,11 @@
     "cardGroup": "SuperM",
     "name": "Ten",
     "group": "NCT",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001564/osmtn_ordinary_superm_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001564/osmtn_ordinary_superm_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "osmty",
@@ -55,9 +65,11 @@
     "cardGroup": "SuperM",
     "name": "Taeyong",
     "group": "NCT",
-    "types": "",
+    "types": ["Fire"],
     "rarity": "Common",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001579/osmty_ordinary_superm_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001579/osmty_ordinary_superm_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "usmbh",
@@ -65,9 +77,11 @@
     "cardGroup": "SuperM",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": "",
+    "types": ["Water"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160143/usmbh_unordinary_superm_baekhyun_v1n2aq.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160143/usmbh_unordinary_superm_baekhyun_v1n2aq.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "usmka",
@@ -75,9 +89,11 @@
     "cardGroup": "SuperM",
     "name": "Kai",
     "group": "EXO",
-    "types": "",
+    "types": ["Darkness"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160147/usmka_unordinary_superm_kai_gbpmfl.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160147/usmka_unordinary_superm_kai_gbpmfl.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "usmmk",
@@ -85,19 +101,23 @@
     "cardGroup": "SuperM",
     "name": "Mark",
     "group": "NCT",
-    "types": "",
+    "types": ["Darkness"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001698/usmmk_unordinary_superm_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001698/usmmk_unordinary_superm_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "usmtm",
     "cardRarity": "Unordinary",
     "cardGroup": "SuperM",
     "name": "Taemin",
-    "group": "Shinee",
-    "types": "",
+    "group": "SHINee",
+    "types": ["Darkness"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001714/usmtm_unordinary_superm_taemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001714/usmtm_unordinary_superm_taemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "usmtn",
@@ -105,9 +125,11 @@
     "cardGroup": "SuperM",
     "name": "Ten",
     "group": "NCT",
-    "types": "",
+    "types": ["Darkness"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001729/usmtn_unordinary_superm_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001729/usmtn_unordinary_superm_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "usmty",
@@ -115,9 +137,11 @@
     "cardGroup": "SuperM",
     "name": "Taeyong",
     "group": "NCT",
-    "types": "",
+    "types": ["Darkness"],
     "rarity": "Rare Secret",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001746/usmty_unordinary_superm_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001746/usmty_unordinary_superm_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "rsmbh",
@@ -125,9 +149,11 @@
     "cardGroup": "SuperM",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": "",
+    "types": ["Water"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160227/rsmbh_rare_superm_baekhyun_s70oyp.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160227/rsmbh_rare_superm_baekhyun_s70oyp.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rsmka",
@@ -135,9 +161,11 @@
     "cardGroup": "SuperM",
     "name": "Kai",
     "group": "EXO",
-    "types": "",
+    "types": ["Fighting"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160231/rsmka_rare_superm_kai_fhkz0x.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160231/rsmka_rare_superm_kai_fhkz0x.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rsmmk",
@@ -145,19 +173,23 @@
     "cardGroup": "SuperM",
     "name": "Mark",
     "group": "NCT",
-    "types": "",
+    "types": ["Fighting"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001594/rsmmk_rare_superm_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001594/rsmmk_rare_superm_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "rsmtm",
     "cardRarity": "Rare",
     "cardGroup": "SuperM",
     "name": "Taemin",
-    "group": "Shinee",
-    "types": "",
+    "group": "SHINee",
+    "types": ["Fighting"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001608/rsmtm_rare_superm_taemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001608/rsmtm_rare_superm_taemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "rsmtn",
@@ -165,9 +197,11 @@
     "cardGroup": "SuperM",
     "name": "Ten",
     "group": "NCT",
-    "types": "",
+    "types": ["Fighting"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001623/rsmtn_rare_superm_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001623/rsmtn_rare_superm_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "rsmty",
@@ -175,9 +209,11 @@
     "cardGroup": "SuperM",
     "name": "Taeyong",
     "group": "NCT",
-    "types": "",
+    "types": ["Water"],
     "rarity": "Rare Holo",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729003097/rsmty_rare_superm_taeyong_1_vg1hkx.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729003097/rsmty_rare_superm_taeyong_1_vg1hkx.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "ssmbh",
@@ -185,9 +221,11 @@
     "cardGroup": "SuperM",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": "",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160236/ssmbh_special_superm_baekhyun_k08vak.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160236/ssmbh_special_superm_baekhyun_k08vak.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ssmka",
@@ -195,9 +233,11 @@
     "cardGroup": "SuperM",
     "name": "Kai",
     "group": "EXO",
-    "types": "",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160239/ssmka_special_superm_kai_yg3ctm.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160239/ssmka_special_superm_kai_yg3ctm.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ssmmk",
@@ -205,19 +245,23 @@
     "cardGroup": "SuperM",
     "name": "Mark",
     "group": "NCT",
-    "types": "",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001638/ssmmk_special_superm_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001638/ssmmk_special_superm_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "ssmtm",
     "cardRarity": "Special",
     "cardGroup": "SuperM",
     "name": "Taemin",
-    "group": "Shinee",
-    "types": "",
+    "group": "SHINee",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001652/ssmtm_special_superm_taemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001652/ssmtm_special_superm_taemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "ssmtn",
@@ -225,9 +269,11 @@
     "cardGroup": "SuperM",
     "name": "Ten",
     "group": "NCT",
-    "types": "",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001668/ssmtn_special_superm_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001668/ssmtn_special_superm_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "ssmty",
@@ -235,9 +281,11 @@
     "cardGroup": "SuperM",
     "name": "Taeyong",
     "group": "NCT",
-    "types": "",
+    "types": ["Dragon"],
     "rarity": "Rare Holo Cosmos",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001684/ssmty_special_superm_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001684/ssmty_special_superm_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   },
   {
     "id": "esmbh",
@@ -245,9 +293,11 @@
     "cardGroup": "SuperM",
     "name": "Baekhyun",
     "group": "EXO",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160244/esmbh_extraordinary_superm_baekhyun_fusbmj.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160244/esmbh_extraordinary_superm_baekhyun_fusbmj.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "esmka",
@@ -255,9 +305,11 @@
     "cardGroup": "SuperM",
     "name": "Kai",
     "group": "EXO",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160247/esmka_extraordinary_superm_kai_esgs4w.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1728160247/esmka_extraordinary_superm_kai_esgs4w.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "esmmk",
@@ -265,19 +317,23 @@
     "cardGroup": "SuperM",
     "name": "Mark",
     "group": "NCT",
-    "types": "",
+    "types": ["Fire"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001469/esmmk_extraordinary_superm_mark.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001469/esmmk_extraordinary_superm_mark.png",
+    "category": "Regular",
+    "keyword": "Dream NCT127 127"
   },
   {
     "id": "esmtm",
     "cardRarity": "Extraordinary",
     "cardGroup": "SuperM",
     "name": "Taemin",
-    "group": "Shinee",
+    "group": "SHINee",
     "types": "",
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001481/esmtm_extraordinary_superm_taemin.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001481/esmtm_extraordinary_superm_taemin.png",
+    "category": "Regular",
+    "keyword": ""
   },
   {
     "id": "esmtn",
@@ -285,9 +341,11 @@
     "cardGroup": "SuperM",
     "name": "Ten",
     "group": "NCT",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001496/esmtn_extraordinary_superm_ten.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001496/esmtn_extraordinary_superm_ten.png",
+    "category": "Regular",
+    "keyword": "WayV"
   },
   {
     "id": "esmty",
@@ -295,8 +353,10 @@
     "cardGroup": "SuperM",
     "name": "Taeyong",
     "group": "NCT",
-    "types": "",
+    "types": ["Metal"],
     "rarity": "Radiant Rare",
-    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001509/esmty_extraordinary_superm_taeyong.png"
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729001509/esmty_extraordinary_superm_taeyong.png",
+    "category": "Regular",
+    "keyword": "NCT127 127"
   }
 ]

--- a/src/lib/database/svtLibrary.json
+++ b/src/lib/database/svtLibrary.json
@@ -1,2195 +1,3085 @@
 [
-    {
-      "id": "osvdk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881672/osvdk_ordinary_seventeen_dk.png"
-    },
-    {
-      "id": "o2svdk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881629/o2svdk_ordinary_seventeen_dk.png"
-    },
-    {
-      "id": "osvdn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881688/osvdn_ordinary_seventeen_dino.png"
-    },
-    {
-      "id": "o2svdn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881649/o2svdn_ordinary_seventeen_dino.png"
-    },
-    {
-      "id": "osldn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Soloist",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866470/osldn_ordinary_soloist_dino.png"
-    },
-    {
-      "id": "osvhs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881713/osvhs_ordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "o2svhs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Grass"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881700/o2svhs_ordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "oslhs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Soloist",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866757/oslhs_ordinary_soloist_hoshi.png"
-    },
-    {
-      "id": "osvjh",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881776/osvjh_ordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "o2svjh",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881739/o2svjh_ordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "osvjn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881787/osvjn_ordinary_seventeen_jun.png"
-    },
-    {
-      "id": "o2svjn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881762/o2svjn_ordinary_seventeen_jun.png"
-    },
-    {
-      "id": "osljn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Soloist",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867064/osljn_ordinary_soloist_jun.png"
-    },
-    {
-      "id": "osvjs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881827/osvjs_ordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "o2svjs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881816/o2svjs_ordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "osvmg",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881909/osvmg_ordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "o2svmg",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881849/o2svmg_ordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "osvsc",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881952/osvsc_ordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "o2svsc",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881942/o2svsc_ordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "osvsk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881896/osvsk_ordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "o2svsk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881867/o2svsk_ordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "osvt8",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882713/osvt8_ordinary_seventeen_the8.png"
-    },
-    {
-      "id": "o2svt8",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881964/o2svt8_ordinary_seventeen_the8.png"
-    },
-    {
-      "id": "osvvn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882738/osvvn_ordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "o2svvn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882726/o2svvn_ordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "oslvn",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Soloist",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869811/oslvn_ordinary_soloist_vernon.png"
-    },
-    {
-      "id": "osvwo",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882765/osvwo_ordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "o2svwo",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882754/o2svwo_ordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "o2svwz",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882790/o2svwz_ordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "osvwz",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882777/osvwz_ordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "oslwo",
-      "cardRarity": "Ordinary",
-      "cardGroup": "Soloist",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870063/oslwo_ordinary_soloist_woozi.png"
-    },
-    {
-      "id": "usvdk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880334/usvdk_unordinary_seventeen_dk.png"
-    },
-    {
-      "id": "u2svdk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880301/u2svdk_unordinary_seventeen_dk.png"
-    },
-    {
-      "id": "usvdn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880416/usvdn_unordinary_seventeen_dino.png"
-    },
-    {
-      "id": "u2svdn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880380/u2svdn_unordinary_seventeen_dino.png"
-    },
-    {
-      "id": "usldn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Soloist",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866638/usldn_unordinary_soloist_dino.png"
-    },
-    {
-      "id": "usvhs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Grass"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880619/usvhs_unordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "u2svhs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880525/u2svhs_unordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "uslhs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Soloist",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866923/uslhs_unordinary_soloist_hoshi.png"
-    },
-    {
-      "id": "usvjh",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880706/usvjh_unordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "u2svjh",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880666/u2svjh_unordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "usvjn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880893/usvjn_unordinary_seventeen_jun.png"
-    },
-    {
-      "id": "u2svjn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880785/u2svjn_unordinary_seventeen_jun.png"
-    },
-    {
-      "id": "usljn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Soloist",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869477/usljn_unordinary_soloist_jun.png"
-    },
-    {
-      "id": "usvjs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881082/usvjs_unordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "u2svjs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881018/u2svjs_unordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "usvmg",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881122/usvmg_unordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "u2svmg",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881111/u2svmg_unordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "usvsc",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881217/usvsc_unordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "u2svsc",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881176/u2svsc_unordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "usvsk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881164/usvsk_unordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "u2svsk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881148/u2svsk_unordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "usvt8",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881267/usvt8_unordinary_seventeen_the8.png"
-    },
-    {
-      "id": "u2svt8",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881246/u2svt8_unordinary_seventeen_the8.png"
-    },
-    {
-      "id": "usvvn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881302/usvvn_unordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "u2svvn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881284/u2svvn_unordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "uslvn",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Soloist",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869975/uslvn_unordinary_soloist_vernon.png"
-    },
-    {
-      "id": "usvwo",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881384/usvwo_unordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "u2svwo",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881341/u2svwo_unordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "usvwz",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Grass"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881398/usvwz_unordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "u2svwz",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881368/u2svwz_unordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "uslwo",
-      "cardRarity": "Unordinary",
-      "cardGroup": "Soloist",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870191/uslwo_unordinary_soloist_woozi.png"
-    },
-    {
-      "id": "rsvdk",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878819/rsvdk_rare_seventeen_dk.png"
-    },
-    {
-      "id": "r2svdk",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878782/r2svdk_rare_seventeen_dk.png"
-    },
-    {
-      "id": "rsvdn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878929/rsvdn_rare_seventeen_dino.png"
-    },
-    {
-      "id": "r2svdn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878863/r2svdn_rare_seventeen_dino.png"
-    },
-    {
-      "id": "rsldn",
-      "cardRarity": "Rare",
-      "cardGroup": "Soloist",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866553/rsldn_rare_soloist_dino.png"
-    },
-    {
-      "id": "rsvhs",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879051/rsvhs_rare_seventeen_hoshi.png"
-    },
-    {
-      "id": "r2svhs",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878968/r2svhs_rare_seventeen_hoshi.png"
-    },
-    {
-      "id": "rslhs",
-      "cardRarity": "Rare",
-      "cardGroup": "Soloist",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866810/rslhs_rare_soloist_hoshi.png"
-    },
-    {
-      "id": "rsvjh",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879115/rsvjh_rare_seventeen_jeonghan.png"
-    },
-    {
-      "id": "r2svjh",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879079/r2svjh_rare_seventeen_jeonghan.png"
-    },
-    {
-      "id": "rsvjn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879200/rsvjn_rare_seventeen_jun.png"
-    },
-    {
-      "id": "r2svjn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879151/r2svjn_rare_seventeen_jun.png"
-    },
-    {
-      "id": "rsljn",
-      "cardRarity": "Rare",
-      "cardGroup": "Soloist",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867167/rsljn_rare_soloist_jun.png"
-    },
-    {
-      "id": "rsvjs",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879294/rsvjs_rare_seventeen_joshua.png"
-    },
-    {
-      "id": "r2svjs",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879238/r2svjs_rare_seventeen_joshua.png"
-    },
-    {
-      "id": "rsvmg",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879402/rsvmg_rare_seventeen_mingyu.png"
-    },
-    {
-      "id": "r2svmg",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879348/r2svmg_rare_seventeen_mingyu.png"
-    },
-    {
-      "id": "rsvsc",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879614/rsvsc_rare_seventeen_s.coups.png"
-    },
-    {
-      "id": "r2svsc",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879573/r2svsc_rare_seventeen_s.coups.png"
-    },
-    {
-      "id": "rsvsk",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879531/rsvsk_rare_seventeen_seungkwan.png"
-    },
-    {
-      "id": "r2svsk",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879488/r2svsk_rare_seventeen_seungkwan.png"
-    },
-    {
-      "id": "rsvt8",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879692/rsvt8_rare_seventeen_the8.png"
-    },
-    {
-      "id": "r2svt8",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879655/r2svt8_rare_seventeen_the8.png"
-    },
-    {
-      "id": "rsvvn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879784/rsvvn_rare_seventeen_vernon.png"
-    },
-    {
-      "id": "r2svvn",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879731/r2svvn_rare_seventeen_vernon.png"
-    },
-    {
-      "id": "rslvn",
-      "cardRarity": "Rare",
-      "cardGroup": "Soloist",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869862/rslvn_rare_soloist_vernon.png"
-    },
-    {
-      "id": "rsvwo",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879946/rsvwo_rare_seventeen_wonwoo.png"
-    },
-    {
-      "id": "r2svwo",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879891/r2svwo_rare_seventeen_wonwoo.png"
-    },
-    {
-      "id": "rsvwz",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880014/rsvwz_rare_seventeen_woozi.png"
-    },
-    {
-      "id": "r2svwz",
-      "cardRarity": "Rare",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879982/r2svwz_rare_seventeen_woozi.png"
-    },
-    {
-      "id": "rslwo",
-      "cardRarity": "Rare",
-      "cardGroup": "Soloist",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870114/rslwo_rare_soloist_woozi.png"
-    },
-    {
-      "id": "ssvdk",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877357/ssvdk_special_seventeen_dk.png"
-    },
-    {
-      "id": "s2svdk",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877315/s2svdk_special_seventeen_dk.png"
-    },
-    {
-      "id": "ssvdn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877443/ssvdn_special_seventeen_dino.png"
-    },
-    {
-      "id": "s2svdn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877394/s2svdn_special_seventeen_dino.png"
-    },
-    {
-      "id": "ssldn",
-      "cardRarity": "Special",
-      "cardGroup": "Soloist",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866596/ssldn_special_soloist_dino.png"
-    },
-    {
-      "id": "ssvhs",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877716/ssvhs_special_seventeen_hoshi.png"
-    },
-    {
-      "id": "s2svhs",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877672/s2svhs_special_seventeen_hoshi.png"
-    },
-    {
-      "id": "sslhs",
-      "cardRarity": "Special",
-      "cardGroup": "Soloist",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866863/sslhs_special_soloist_hoshi.png"
-    },
-    {
-      "id": "ssvjh",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877519/ssvjh_special_seventeen_jeonghan.png"
-    },
-    {
-      "id": "s2svjh",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877477/s2svjh_special_seventeen_jeonghan.png"
-    },
-    {
-      "id": "ssvjn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877620/ssvjn_special_seventeen_jun.png"
-    },
-    {
-      "id": "s2svjn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877565/s2svjn_special_seventeen_jun.png"
-    },
-    {
-      "id": "ssljn",
-      "cardRarity": "Special",
-      "cardGroup": "Soloist",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867249/ssljn_special_soloist_jun.png"
-    },
-    {
-      "id": "ssvjs",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877836/ssvjs_special_seventeen_joshua.png"
-    },
-    {
-      "id": "s2svjs",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877774/s2svjs_special_seventeen_joshua.png"
-    },
-    {
-      "id": "ssvmg",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877936/ssvmg_special_seventeen_mingyu.png"
-    },
-    {
-      "id": "s2svmg",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877892/s2svmg_special_seventeen_mingyu.png"
-    },
-    {
-      "id": "ssvsc",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878092/ssvsc_special_seventeen_s.coups.png"
-    },
-    {
-      "id": "s2svsc",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878053/s2svsc_special_seventeen_s.coups.png"
-    },
-    {
-      "id": "ssvsk",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878016/ssvsk_special_seventeen_seungkwan.png"
-    },
-    {
-      "id": "s2svsk",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877981/s2svsk_special_seventeen_seungkwan.png"
-    },
-    {
-      "id": "ssvt8",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878186/ssvt8_special_seventeen_the8.png"
-    },
-    {
-      "id": "s2svt8",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878142/s2svt8_special_seventeen_the8.png"
-    },
-    {
-      "id": "ssvvn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878291/ssvvn_special_seventeen_vernon.png"
-    },
-    {
-      "id": "s2svvn",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878247/s2svvn_special_seventeen_vernon.png"
-    },
-    {
-      "id": "sslvn",
-      "cardRarity": "Special",
-      "cardGroup": "Soloist",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869905/sslvn_special_soloist_vernon.png"
-    },
-    {
-      "id": "ssvwo",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878460/ssvwo_special_seventeen_wonwoo.png"
-    },
-    {
-      "id": "s2svwo",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878427/s2svwo_special_seventeen_wonwoo.png"
-    },
-    {
-      "id": "ssvwz",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878553/ssvwz_special_seventeen_woozi.png"
-    },
-    {
-      "id": "s2svwz",
-      "cardRarity": "Special",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878509/s2svwz_special_seventeen_woozi.png"
-    },
-    {
-      "id": "sslwo",
-      "cardRarity": "Special",
-      "cardGroup": "Soloist",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870150/sslwo_special_soloist_woozi.png"
-    },
-    {
-      "id": "esvdk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875755/esvdk_extraordinary_seventeen_dk.png"
-    },
-    {
-      "id": "e2svdk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874644/e2svdk_extraordinary_seventeen_dk.png"
-    },
-    {
-      "id": "esvdn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875838/esvdn_extraordinary_seventeen_dino.png"
-    },
-    {
-      "id": "e2svdn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874743/e2svdn_extraordinary_seventeen_dino.png"
-    },
-    {
-      "id": "esldn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Soloist",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866402/esldn_extraordinary_soloist_dino.png"
-    },
-    {
-      "id": "esvhs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876094/esvhs_extraordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "e2svhs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874888/e2svhs_extraordinary_seventeen_hoshi.png"
-    },
-    {
-      "id": "eslhs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Soloist",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866706/eslhs_extraordinary_soloist_hoshi.png"
-    },
-    {
-      "id": "esvjh",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Psychic"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876198/esvjh_extraordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "e2svjh",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874974/e2svjh_extraordinary_seventeen_jeonghan.png"
-    },
-    {
-      "id": "esvjn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876257/esvjn_extraordinary_seventeen_jun.png"
-    },
-    {
-      "id": "e2svjn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875068/e2svjn_extraordinary_seventeen_jun.png"
-    },
-    {
-      "id": "esljn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Soloist",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867013/esljn_extraordinary_soloist_jun.png"
-    },
-    {
-      "id": "esvjs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876311/esvjs_extraordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "e2svjs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875137/e2svjs_extraordinary_seventeen_joshua.png"
-    },
-    {
-      "id": "esvmg",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876404/esvmg_extraordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "e2svmg",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875297/e2svmg_extraordinary_seventeen_mingyu.png"
-    },
-    {
-      "id": "esvsc",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Psychic"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876504/esvsc_extraordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "e2svsc",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875427/e2svsc_extraordinary_seventeen_s.coups.png"
-    },
-    {
-      "id": "esvsk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876558/esvsk_extraordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "e2svsk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875396/e2svsk_extraordinary_seventeen_seungkwan.png"
-    },
-    {
-      "id": "esvt8",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876619/esvt8_extraordinary_seventeen_the8.png"
-    },
-    {
-      "id": "e2svt8",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875503/e2svt8_extraordinary_seventeen_the8.png"
-    },
-    {
-      "id": "esvvn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876659/esvvn_extraordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "e2svvn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875560/e2svvn_extraordinary_seventeen_vernon.png"
-    },
-    {
-      "id": "eslvn",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Soloist",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869716/eslvn_extraordinary_soloist_vernon.png"
-    },
-    {
-      "id": "esvwo",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876708/esvwo_extraordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "e2svwo",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875636/e2svwo_extraordinary_seventeen_wonwoo.png"
-    },
-    {
-      "id": "esvwz",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876753/esvwz_extraordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "e2svwz",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Seventeen",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875673/e2svwz_extraordinary_seventeen_woozi.png"
-    },
-    {
-      "id": "eslwo",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "Soloist",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870022/eslwo_extraordinary_soloist_woozi.png"
-    },
-    {
-      "id": "fethju",
-      "cardRarity": "Priceless",
-      "cardGroup": "Pfriendship Event",
-      "name": "The8 & Jun",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886196/fethju_priceless_Pfriendship%20Event_the8_jun.png"
-    },
-    {
-      "id": "fesemo",
-      "cardRarity": "Priceless",
-      "cardGroup": "Friendship Event",
-      "name": "Moonbin & Seungkwan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886060/fesemo_priceless_Friendship%20Event_moonbin_seungkwan.png"
-    },
-    {
-      "id": "amedkk",
-      "cardRarity": "Priceless",
-      "cardGroup": "Amethyst",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871725/amedkk_priceless_amethyst_dk.png"
-    },
-    {
-      "id": "paqdk",
-      "cardRarity": "Priceless",
-      "cardGroup": "Aphrodite",
-      "name": "DK",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871797/paqdk_priceless_aphrodite_dk.png"
-    },
-    {
-      "id": "amedin",
-      "cardRarity": "Priceless",
-      "cardGroup": "Amethyst",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871882/amedin_priceless_amethyst_dino.png"
-    },
-    {
-      "id": "sumdin",
-      "cardRarity": "Priceless",
-      "cardGroup": "Summer Event Bsummer",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871949/sumdin_priceless_bsummer_dino.png"
-    },
-    {
-      "id": "xodin",
-      "cardRarity": "Priceless",
-      "cardGroup": "XOXO Event",
-      "name": "Dino",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872528/xodin_priceless_XOXO_dino.png"
-    },
-    {
-      "id": "alehos",
-      "cardRarity": "Priceless",
-      "cardGroup": "Alexandrite",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Psychic"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872603/alehos_priceless_alexandrite_hoshi.png"
-    },
-    {
-      "id": "apfshi",
-      "cardRarity": "Priceless",
-      "cardGroup": "April Fools Event Apf",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873104/apfshi_priceless_apf_hoshi.png"
-    },
-    {
-      "id": "xmhsi",
-      "cardRarity": "Priceless",
-      "cardGroup": "Xmas Xmas23",
-      "name": "Hoshi",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873202/xmhsi_priceless_xmas23_hoshi.png"
-    },
-    {
-      "id": "evghan",
-      "cardRarity": "Priceless",
-      "cardGroup": "Evil Event",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873300/evghan_priceless_evil_jeonghan.png"
-    },
-    {
-      "id": "faejhn",
-      "cardRarity": "Priceless",
-      "cardGroup": "Fairy Fairies Event Bfairies",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873347/faejhn_priceless_bfairies_jeonghan.png"
-    },
-    {
-      "id": "libjeo",
-      "cardRarity": "Priceless",
-      "cardGroup": "Libra",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873457/libjeo_priceless_libra_jeonghan.png"
-    },
-    {
-      "id": "royhan",
-      "cardRarity": "Priceless",
-      "cardGroup": "Royal Event",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873512/royhan_priceless_Royal%20Event_jeonghan.png"
-    },
-    {
-      "id": "hbdpocket",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staff Birthday",
-      "name": "Jeonghan",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873402/hbdpocket_priceless_Staff%20Birthday_jeonghan.png"
-    },
-    {
-      "id": "alejun",
-      "cardRarity": "Priceless",
-      "cardGroup": "Alexandrite",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881927/alejun_priceless_alexandrite_jun.png"
-    },
-    {
-      "id": "srojun",
-      "cardRarity": "Priceless",
-      "cardGroup": "Psanrio",
-      "name": "Jun",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882042/srojun_priceless_psanrio_jun.png"
-    },
-    {
-      "id": "hbdsophiya",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staff Birthday",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882710/hbdsophiya_priceless_Staff%20Birthday_joshua.png"
-    },
-    {
-      "id": "hbdcami",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staff Birthday",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882512/hbdcami_priceless_Staff%20Birthday_joshua.png"
-    },
-    {
-      "id": "sfmami",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staffmate Event",
-      "name": "Joshua",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882760/sfmami_priceless_staffmate_joshua.png"
-    },
-    {
-      "id": "zuhmgy",
-      "cardRarity": "Priceless",
-      "cardGroup": "Pcardcaptor",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883130/zuhmgy_priceless_pcardcaptor_mingyu.png"
-    },
-    {
-      "id": "diagyu",
-      "cardRarity": "Priceless",
-      "cardGroup": "Diamond",
-      "name": "Mingyu",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883074/diagyu_priceless_diamond_mingyu.png"
-    },
-    {
-      "id": "btasco",
-      "cardRarity": "Priceless",
-      "cardGroup": "BTA",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883258/btasco_priceless_BTA_s.coups.png"
-    },
-    {
-      "id": "leoups",
-      "cardRarity": "Priceless",
-      "cardGroup": "Leo",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883364/leoups_priceless_leo_s.coups.png"
-    },
-    {
-      "id": "sarsco",
-      "cardRarity": "Priceless",
-      "cardGroup": "Sardonyx",
-      "name": "S.Coups",
-      "group": "Seventeen",
-      "types": ["Dragon"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883470/sarsco_priceless_sardonyx_s.coups.png"
-    },
-    {
-      "id": "hbdtellie",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staff Birthday",
-      "name": "Seungkwan",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883556/hbdtellie_priceless_Staff%20Birthday_seungkwan.png"
-    },
-    {
-      "id": "cdythe",
-      "cardRarity": "Priceless",
-      "cardGroup": "Candy Event Bcandy",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Psychic"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883864/cdythe_priceless_bcandy_the8.png"
-    },
-    {
-      "id": "scothe",
-      "cardRarity": "Priceless",
-      "cardGroup": "Scorpio",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883960/scothe_priceless_scorpio_the8.png"
-    },
-    {
-      "id": "pset8",
-      "cardRarity": "Priceless",
-      "cardGroup": "Stardust Event",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883902/pset8_priceless_Stardust%20Event_the8.png"
-    },
-    {
-      "id": "tyuth8",
-      "cardRarity": "Priceless",
-      "cardGroup": "Pthanku",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884091/tyuth8_priceless_pthanku_the8.png"
-    },
-    {
-      "id": "amever",
-      "cardRarity": "Priceless",
-      "cardGroup": "Amethyst",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Psychic"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884165/amever_priceless_amethyst_vernon.png"
-    },
-    {
-      "id": "apover",
-      "cardRarity": "Priceless",
-      "cardGroup": "Apocalypse Event Papocalypse",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884197/apover_priceless_papocalypse_vernon.png"
-    },
-    {
-      "id": "sfmshy",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staffmate Event",
-      "name": "Vernon",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884239/sfmshy_priceless_staffmate_vernon.png"
-    },
-    {
-      "id": "canwon",
-      "cardRarity": "Priceless",
-      "cardGroup": "Cancer",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884302/canwon_priceless_cancer_wonwoo.png"
-    },
-    {
-      "id": "ubywoo",
-      "cardRarity": "Priceless",
-      "cardGroup": "Ruby",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884378/ubywoo_priceless_ruby_wonwoo.png"
-    },
-    {
-      "id": "slmwwo",
-      "cardRarity": "Priceless",
-      "cardGroup": "Soulmate Event",
-      "name": "Wonwoo",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884344/slmwwo_priceless_soulmate_wonwoo.png"
-    },
-    {
-      "id": "sagwoo",
-      "cardRarity": "Priceless",
-      "cardGroup": "Sagittarius",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Lightning"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884487/sagwoo_priceless_sagittarius_woozi.png"
-    },
-    {
-      "id": "hbdlou",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staff Birthday",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Water"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884439/hbdlou_priceless_Staff%20Birthday_woozi.png"
-    },
-    {
-      "id": "sfmnco",
-      "cardRarity": "Priceless",
-      "cardGroup": "Staffmate Event",
-      "name": "Woozi",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884529/sfmnco_priceless_staffmate_woozi.png"
-    },
-    {
-      "id": "ansvbcs",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "Vernon & Dino & Seungkwan & BooChanSol",
-      "group": "Seventeen",
-      "types": ["Grass"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885647/ansvbcs_altair_anniversary_Vernon%20Dino%20Seungkwan.png"
-    },
-    {
-      "id": "ansvjc",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "S.Coups & Jeonghan & JeongCheol",
-      "group": "Seventeen",
-      "types": ["Fire"],
-      "rarity": "Amazing Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885527/ansvjc_altair_anniversary_S.Coups%20Jeonghan.png",
-      "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
-    },
-    {
-      "id": "ansvsh",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "Hoshi & Woozi & SoonHoon",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Trainer Gallery Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885425/ansvsh_altair_anniversary_Hoshi%20Woozi.png"
-    },
-    {
-      "id": "ansvss",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "Seungkwan & DK & SeokSoo",
-      "group": "Seventeen",
-      "types": ["Fighting"],
-      "rarity": "Amazing Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885187/ansvss_altair_anniversary_Seungkwan%20DK.png",
-      "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
-    },
-    {
-      "id": "ansvmw",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "Mingyu & Wonwoo & MinWon",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Amazing Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885017/ansvmw_altair_anniversary_Mingyu%20Wonwoo.png",
-      "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
-    },
-    {
-      "id": "ansvjh",
-      "cardRarity": "Altair",
-      "cardGroup": "Anniversary",
-      "name": "Jun & The8 & JunHao",
-      "group": "Seventeen",
-      "types": ["Grass"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884947/ansvjh_altair_anniversary_Jun%20The8.png"
-    },
-    {
-      "id": "foolpic",
-      "cardRarity": "Altair",
-      "cardGroup": "Fools",
-      "name": "Pi Cheolin & Dino",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Trainer Gallery Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887787/foolpic_altair_fools_Pi%20Cheolin_dino.png"
-    },
-    {
-      "id": "kittyjayjun",
-      "cardRarity": "Altair",
-      "cardGroup": "Kitties",
-      "name": "Jay & Jun",
-      "group": "Seventeen",
-      "types": ["Metal"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887398/kittyjayjun_altair_kitties_Jay%20Jun.png"
-    },
-    {
-      "id": "xmasseoksoo",
-      "cardRarity": "Altair",
-      "cardGroup": "Xmas",
-      "name": "Joshua & DK & SeokSoo",
-      "group": "Seventeen",
-      "types": ["Fairy"],
-      "rarity": "Rare Shiny",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887721/xmasseoksoo_altair_xmas_Joshua%20DK.png"
-    },
-    {
-      "id": "woofhao",
-      "cardRarity": "Altair",
-      "cardGroup": "Wild Animal",
-      "name": "The8",
-      "group": "Seventeen",
-      "types": ["Darkness"],
-      "rarity": "Rare Holo VSTAR",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883672/woofhao_altair_Wild%20Animal_the8.png"
-    },
-    {
-      "id": "obsdk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "BSS",
-      "name": "DK",
-      "group": "BSS",
-      "types": ["Darkness"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864973/obsdk_ordinary_BSS_dk.png"
-    },
-    {
-      "id": "obshs",
-      "cardRarity": "Ordinary",
-      "cardGroup": "BSS",
-      "name": "Hoshi",
-      "group": "BSS",
-      "types": ["Darkness"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865054/obshs_ordinary_BSS_hoshi.png"
-    },
-    {
-      "id": "obssk",
-      "cardRarity": "Ordinary",
-      "cardGroup": "BSS",
-      "name": "Seungkwan",
-      "group": "BSS",
-      "types": ["Darkness"],
-      "rarity": "Common",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865120/oBSSk_ordinary_BSS_seungkwan.png"
-    },
-    {
-      "id": "ubsdk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "BSS",
-      "name": "DK",
-      "group": "BSS",
-      "types": ["Metal"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865521/ubsdk_unordinary_BSS_dk.png"
-    },
-    {
-      "id": "ubshs",
-      "cardRarity": "Unordinary",
-      "cardGroup": "BSS",
-      "name": "Hoshi",
-      "group": "BSS",
-      "types": ["Psychic"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865576/ubshs_unordinary_BSS_hoshi.png"
-    },
-    {
-      "id": "ubssk",
-      "cardRarity": "Unordinary",
-      "cardGroup": "BSS",
-      "name": "Seungkwan",
-      "group": "BSS",
-      "types": ["Fighting"],
-      "rarity": "Rare Secret",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865620/uBSSk_unordinary_BSS_seungkwan.png"
-    },
-    {
-      "id": "rbsdk",
-      "cardRarity": "Rare",
-      "cardGroup": "BSS",
-      "name": "DK",
-      "group": "BSS",
-      "types": ["Darkness"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865174/rbsdk_rare_BSS_dk.png"
-    },
-    {
-      "id": "rbshs",
-      "cardRarity": "Rare",
-      "cardGroup": "BSS",
-      "name": "Hoshi",
-      "group": "BSS",
-      "types": ["Water"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865221/rbshs_rare_BSS_hoshi.png"
-    },
-    {
-      "id": "rbssk",
-      "cardRarity": "Rare",
-      "cardGroup": "BSS",
-      "name": "Seungkwan",
-      "group": "BSS",
-      "types": ["Fire"],
-      "rarity": "Rare Holo",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865270/rBSSk_rare_BSS_seungkwan.png"
-    },
-    {
-      "id": "sbsdk",
-      "cardRarity": "Special",
-      "cardGroup": "BSS",
-      "name": "DK",
-      "group": "BSS",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865328/sbsdk_special_BSS_dk.png"
-    },
-    {
-      "id": "sbshs",
-      "cardRarity": "Special",
-      "cardGroup": "BSS",
-      "name": "Hoshi",
-      "group": "BSS",
-      "types": ["Lightning"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865394/sbshs_special_BSS_hoshi.png"
-    },
-    {
-      "id": "sbssk",
-      "cardRarity": "Special",
-      "cardGroup": "BSS",
-      "name": "Seungkwan",
-      "group": "BSS",
-      "types": ["Grass"],
-      "rarity": "Rare Holo Cosmos",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865457/sBSSk_special_BSS_seungkwan.png"
-    },
-    {
-      "id": "ebsdk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "BSS",
-      "name": "DK",
-      "group": "BSS",
-      "types": ["Fighting"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864332/ebsdk_extraordinary_BSS_dk.png"
-    },
-    {
-      "id": "ebshs",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "BSS",
-      "name": "Hoshi",
-      "group": "BSS",
-      "types": ["Metal"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864845/ebshs_extraordinary_BSS_hoshi.png"
-    },
-    {
-      "id": "ebssk",
-      "cardRarity": "Extraordinary",
-      "cardGroup": "BSS",
-      "name": "Seungkwan",
-      "group": "BSS",
-      "types": ["Fighting"],
-      "rarity": "Radiant Rare",
-      "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864925/eBSSk_extraordinary_BSS_seungkwan.png"
-    }
-  ]
+  {
+    "id": "osvdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881672/osvdk_ordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881629/o2svdk_ordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvdn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881688/osvdn_ordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svdn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881649/o2svdn_ordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osldn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866470/osldn_ordinary_soloist_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881713/osvhs_ordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881700/o2svhs_ordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "oslhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866757/oslhs_ordinary_soloist_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881776/osvjh_ordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881739/o2svjh_ordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881787/osvjn_ordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881762/o2svjn_ordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osljn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867064/osljn_ordinary_soloist_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvjs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881827/osvjs_ordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svjs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881816/o2svjs_ordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvmg",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881909/osvmg_ordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svmg",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881849/o2svmg_ordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvsc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881952/osvsc_ordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "o2svsc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881942/o2svsc_ordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "osvsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881896/osvsk_ordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881867/o2svsk_ordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvt8",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882713/osvt8_ordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svt8",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881964/o2svt8_ordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882738/osvvn_ordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882726/o2svvn_ordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "oslvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869811/oslvn_ordinary_soloist_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882765/osvwo_ordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882754/o2svwo_ordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "o2svwz",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882790/o2svwz_ordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "osvwz",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882777/osvwz_ordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "oslwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870063/oslwo_ordinary_soloist_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880334/usvdk_unordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880301/u2svdk_unordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvdn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880416/usvdn_unordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svdn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880380/u2svdn_unordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usldn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866638/usldn_unordinary_soloist_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880619/usvhs_unordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880525/u2svhs_unordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "uslhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866923/uslhs_unordinary_soloist_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880706/usvjh_unordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880666/u2svjh_unordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880893/usvjn_unordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880785/u2svjn_unordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usljn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869477/usljn_unordinary_soloist_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvjs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881082/usvjs_unordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svjs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881018/u2svjs_unordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvmg",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881122/usvmg_unordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svmg",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881111/u2svmg_unordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvsc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881217/usvsc_unordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "u2svsc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881176/u2svsc_unordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "usvsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881164/usvsk_unordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881148/u2svsk_unordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvt8",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881267/usvt8_unordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svt8",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881246/u2svt8_unordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881302/usvvn_unordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881284/u2svvn_unordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "uslvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869975/uslvn_unordinary_soloist_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881384/usvwo_unordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881341/u2svwo_unordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "usvwz",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881398/usvwz_unordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "u2svwz",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881368/u2svwz_unordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "uslwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870191/uslwo_unordinary_soloist_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvdk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878819/rsvdk_rare_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svdk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878782/r2svdk_rare_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvdn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878929/rsvdn_rare_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svdn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878863/r2svdn_rare_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsldn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866553/rsldn_rare_soloist_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879051/rsvhs_rare_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878968/r2svhs_rare_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rslhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866810/rslhs_rare_soloist_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvjh",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879115/rsvjh_rare_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svjh",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879079/r2svjh_rare_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvjn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879200/rsvjn_rare_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svjn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879151/r2svjn_rare_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsljn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867167/rsljn_rare_soloist_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvjs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879294/rsvjs_rare_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svjs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879238/r2svjs_rare_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvmg",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879402/rsvmg_rare_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svmg",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879348/r2svmg_rare_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvsc",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879614/rsvsc_rare_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "r2svsc",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879573/r2svsc_rare_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "rsvsk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879531/rsvsk_rare_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svsk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879488/r2svsk_rare_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvt8",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879692/rsvt8_rare_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svt8",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879655/r2svt8_rare_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879784/rsvvn_rare_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879731/r2svvn_rare_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rslvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869862/rslvn_rare_soloist_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879946/rsvwo_rare_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879891/r2svwo_rare_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rsvwz",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880014/rsvwz_rare_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "r2svwz",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879982/r2svwz_rare_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rslwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870114/rslwo_rare_soloist_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvdk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877357/ssvdk_special_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svdk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877315/s2svdk_special_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvdn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877443/ssvdn_special_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svdn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877394/s2svdn_special_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssldn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866596/ssldn_special_soloist_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvhs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877716/ssvhs_special_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svhs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877672/s2svhs_special_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sslhs",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866863/sslhs_special_soloist_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvjh",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877519/ssvjh_special_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svjh",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877477/s2svjh_special_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvjn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877620/ssvjn_special_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svjn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877565/s2svjn_special_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssljn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867249/ssljn_special_soloist_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvjs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877836/ssvjs_special_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svjs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877774/s2svjs_special_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvmg",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877936/ssvmg_special_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svmg",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877892/s2svmg_special_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvsc",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878092/ssvsc_special_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "s2svsc",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878053/s2svsc_special_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "ssvsk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878016/ssvsk_special_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svsk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877981/s2svsk_special_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvt8",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878186/ssvt8_special_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svt8",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878142/s2svt8_special_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvvn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878291/ssvvn_special_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svvn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878247/s2svvn_special_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sslvn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869905/sslvn_special_soloist_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvwo",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878460/ssvwo_special_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svwo",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878427/s2svwo_special_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ssvwz",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878553/ssvwz_special_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "s2svwz",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878509/s2svwz_special_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sslwo",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870150/sslwo_special_soloist_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875755/esvdk_extraordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874644/e2svdk_extraordinary_seventeen_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvdn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875838/esvdn_extraordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svdn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874743/e2svdn_extraordinary_seventeen_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esldn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866402/esldn_extraordinary_soloist_dino.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876094/esvhs_extraordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874888/e2svhs_extraordinary_seventeen_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "eslhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866706/eslhs_extraordinary_soloist_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvjh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876198/esvjh_extraordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svjh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874974/e2svjh_extraordinary_seventeen_jeonghan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876257/esvjn_extraordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875068/e2svjn_extraordinary_seventeen_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esljn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867013/esljn_extraordinary_soloist_jun.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvjs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876311/esvjs_extraordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svjs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875137/e2svjs_extraordinary_seventeen_joshua.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvmg",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876404/esvmg_extraordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svmg",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875297/e2svmg_extraordinary_seventeen_mingyu.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvsc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876504/esvsc_extraordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "e2svsc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875427/e2svsc_extraordinary_seventeen_s.coups.png",
+    "category": "Regular",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "esvsk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876558/esvsk_extraordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svsk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875396/e2svsk_extraordinary_seventeen_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvt8",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876619/esvt8_extraordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svt8",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875503/e2svt8_extraordinary_seventeen_the8.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876659/esvvn_extraordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875560/e2svvn_extraordinary_seventeen_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "eslvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869716/eslvn_extraordinary_soloist_vernon.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876708/esvwo_extraordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875636/e2svwo_extraordinary_seventeen_wonwoo.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "esvwz",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876753/esvwz_extraordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "e2svwz",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875673/e2svwz_extraordinary_seventeen_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "eslwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870022/eslwo_extraordinary_soloist_woozi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "fethju",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pfriendship Event",
+    "name": "The8 & Jun",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886196/fethju_priceless_Pfriendship%20Event_the8_jun.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "fesemo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Friendship Event",
+    "name": "Moonbin & Seungkwan",
+    "group": "Astro Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886060/fesemo_priceless_Friendship%20Event_moonbin_seungkwan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "amedkk",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871725/amedkk_priceless_amethyst_dk.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "paqdk",
+    "cardRarity": "Priceless",
+    "cardGroup": "Aphrodite",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871797/paqdk_priceless_aphrodite_dk.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "amedin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871882/amedin_priceless_amethyst_dino.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "sumdin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Bsummer",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871949/sumdin_priceless_bsummer_dino.png",
+    "category": "Event",
+    "keyword": "SVT Summer"
+  },
+  {
+    "id": "xodin",
+    "cardRarity": "Priceless",
+    "cardGroup": "XOXO",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872528/xodin_priceless_XOXO_dino.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "alehos",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872603/alehos_priceless_alexandrite_hoshi.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "apfshi",
+    "cardRarity": "Priceless",
+    "cardGroup": "Apf",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873104/apfshi_priceless_apf_hoshi.png",
+    "category": "Event",
+    "keyword": "SVT April Fools"
+  },
+  {
+    "id": "xmhsi",
+    "cardRarity": "Priceless",
+    "cardGroup": "Xmas23",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873202/xmhsi_priceless_xmas23_hoshi.png",
+    "category": "Event",
+    "keyword": "SVT Xmas Christmas"
+  },
+  {
+    "id": "evghan",
+    "cardRarity": "Priceless",
+    "cardGroup": "Evil",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873300/evghan_priceless_evil_jeonghan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "faejhn",
+    "cardRarity": "Priceless",
+    "cardGroup": "Bfairies",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873347/faejhn_priceless_bfairies_jeonghan.png",
+    "category": "Event",
+    "keyword": "SVT Fairy Fairies"
+  },
+  {
+    "id": "libjeo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Libra",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873457/libjeo_priceless_libra_jeonghan.png",
+    "category": "Event",
+    "keyword": "Zodiac SVT"
+  },
+  {
+    "id": "royhan",
+    "cardRarity": "Priceless",
+    "cardGroup": "Royal Event",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873512/royhan_priceless_Royal%20Event_jeonghan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "hbdpocket",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873402/hbdpocket_priceless_Staff%20Birthday_jeonghan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "alejun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881927/alejun_priceless_alexandrite_jun.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "srojun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Psanrio",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882042/srojun_priceless_psanrio_jun.png",
+    "category": "Event",
+    "keyword": "SVT Sanrio"
+  },
+  {
+    "id": "hbdsophiya",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882710/hbdsophiya_priceless_Staff%20Birthday_joshua.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "hbdsophiya2",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729778645/hbdsophiya2_priceless_staff%20birthday_joshua.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "hbdcami",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882512/hbdcami_priceless_Staff%20Birthday_joshua.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sfmami",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882760/sfmami_priceless_staffmate_joshua.png",
+    "category": "Event",
+    "keyword": "SVT Staff Mate"
+  },
+  {
+    "id": "zuhmgy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pcardcaptor",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883130/zuhmgy_priceless_pcardcaptor_mingyu.png",
+    "category": "Event",
+    "keyword": "SVT Card Captor"
+  },
+  {
+    "id": "diagyu",
+    "cardRarity": "Priceless",
+    "cardGroup": "Diamond",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883074/diagyu_priceless_diamond_mingyu.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "btasco",
+    "cardRarity": "Priceless",
+    "cardGroup": "BTA",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883258/btasco_priceless_BTA_s.coups.png",
+    "category": "Event",
+    "keyword": "SVT scoups"
+  },
+  {
+    "id": "leoups",
+    "cardRarity": "Priceless",
+    "cardGroup": "Leo",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883364/leoups_priceless_leo_s.coups.png",
+    "category": "Event",
+    "keyword": "Zodiac SVT scoups"
+  },
+  {
+    "id": "sarsco",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": [
+      "Dragon"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883470/sarsco_priceless_sardonyx_s.coups.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT scoups"
+  },
+  {
+    "id": "hbdtellie",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883556/hbdtellie_priceless_Staff%20Birthday_seungkwan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "cdythe",
+    "cardRarity": "Priceless",
+    "cardGroup": "Bcandy",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883864/cdythe_priceless_bcandy_the8.png",
+    "category": "Event",
+    "keyword": "SVT Candy"
+  },
+  {
+    "id": "scothe",
+    "cardRarity": "Priceless",
+    "cardGroup": "Scorpio",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883960/scothe_priceless_scorpio_the8.png",
+    "category": "Event",
+    "keyword": "Zodiac SVT"
+  },
+  {
+    "id": "pset8",
+    "cardRarity": "Priceless",
+    "cardGroup": "Stardust Event",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883902/pset8_priceless_Stardust%20Event_the8.png",
+    "category": "Event",
+    "keyword": "SVT Star Dust"
+  },
+  {
+    "id": "tyuth8",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pthanku",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884091/tyuth8_priceless_pthanku_the8.png",
+    "category": "Event",
+    "keyword": "SVT Thank You"
+  },
+  {
+    "id": "amever",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884165/amever_priceless_amethyst_vernon.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "apover",
+    "cardRarity": "Priceless",
+    "cardGroup": "Apocalypse Event Papocalypse",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884197/apover_priceless_papocalypse_vernon.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sfmshy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884239/sfmshy_priceless_staffmate_vernon.png",
+    "category": "Event",
+    "keyword": "SVT Staff Mate"
+  },
+  {
+    "id": "canwon",
+    "cardRarity": "Priceless",
+    "cardGroup": "Cancer",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884302/canwon_priceless_cancer_wonwoo.png",
+    "category": "Event",
+    "keyword": "Zodiac SVT"
+  },
+  {
+    "id": "ubywoo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Ruby",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884378/ubywoo_priceless_ruby_wonwoo.png",
+    "category": "Gemstone",
+    "keyword": "Event SVT"
+  },
+  {
+    "id": "slmwwo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Soulmate",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884344/slmwwo_priceless_soulmate_wonwoo.png",
+    "category": "Event",
+    "keyword": "SVT Soul Mate"
+  },
+  {
+    "id": "sagwoo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sagittarius",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884487/sagwoo_priceless_sagittarius_woozi.png",
+    "category": "Event",
+    "keyword": "Zodiac SVT"
+  },
+  {
+    "id": "hbdlou",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884439/hbdlou_priceless_Staff%20Birthday_woozi.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sfmnco",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884529/sfmnco_priceless_staffmate_woozi.png",
+    "category": "Event",
+    "keyword": "SVT Staff Mate"
+  },
+  {
+    "id": "ansvbcs",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Vernon & Dino & Seungkwan & BooChanSol",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885647/ansvbcs_altair_anniversary_Vernon%20Dino%20Seungkwan.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ansvjc",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "S.Coups & Jeonghan & JeongCheol",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885527/ansvjc_altair_anniversary_S.Coups%20Jeonghan.png",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ansvsh",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Hoshi & Woozi & SoonHoon",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885425/ansvsh_altair_anniversary_Hoshi%20Woozi.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ansvss",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Seungkwan & DK & SeokSoo",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885187/ansvss_altair_anniversary_Seungkwan%20DK.png",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ansvmw",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Mingyu & Wonwoo & MinWon",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885017/ansvmw_altair_anniversary_Mingyu%20Wonwoo.png",
+    "foil": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ansvjh",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jun & The8 & JunHao",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884947/ansvjh_altair_anniversary_Jun%20The8.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "foolpic",
+    "cardRarity": "Altair",
+    "cardGroup": "Fools",
+    "name": "Pi Cheolin & Dino",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887787/foolpic_altair_fools_Pi%20Cheolin_dino.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "kittyjayjun",
+    "cardRarity": "Altair",
+    "cardGroup": "Kitties",
+    "name": "Jay & Jun",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887398/kittyjayjun_altair_kitties_Jay%20Jun.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "xmasseoksoo",
+    "cardRarity": "Altair",
+    "cardGroup": "Xmas",
+    "name": "Joshua & DK & SeokSoo",
+    "group": "Seventeen",
+    "types": [
+      "Fairy"
+    ],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887721/xmasseoksoo_altair_xmas_Joshua%20DK.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "woofhao",
+    "cardRarity": "Altair",
+    "cardGroup": "Wild Animal",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Holo VSTAR",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883672/woofhao_altair_Wild%20Animal_the8.png",
+    "category": "Event",
+    "keyword": "SVT"
+  },
+  {
+    "id": "obsdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864973/obsdk_ordinary_BSS_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "obshs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865054/obshs_ordinary_BSS_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "obssk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865120/oBSSk_ordinary_BSS_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ubsdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865521/ubsdk_unordinary_BSS_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ubshs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Psychic"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865576/ubshs_unordinary_BSS_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ubssk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865620/uBSSk_unordinary_BSS_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rbsdk",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Darkness"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865174/rbsdk_rare_BSS_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rbshs",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Water"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865221/rbshs_rare_BSS_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "rbssk",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fire"
+    ],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865270/rBSSk_rare_BSS_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sbsdk",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865328/sbsdk_special_BSS_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sbshs",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Lightning"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865394/sbshs_special_BSS_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "sbssk",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Grass"
+    ],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865457/sBSSk_special_BSS_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ebsdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864332/ebsdk_extraordinary_BSS_dk.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ebshs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": [
+      "Metal"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864845/ebshs_extraordinary_BSS_hoshi.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  },
+  {
+    "id": "ebssk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": [
+      "Fighting"
+    ],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864925/eBSSk_extraordinary_BSS_seungkwan.png",
+    "category": "Regular",
+    "keyword": "SVT"
+  }
+]

--- a/src/lib/helpers/cardDataGenerator.js
+++ b/src/lib/helpers/cardDataGenerator.js
@@ -2,6 +2,24 @@ import { writeFileSync } from 'fs';
 
 // 1. Declare a list of several img URLs.
 const imageUrls = [
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwrk_unordinary_nct%20wish_riku.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwys_unordinary_nct%20wish_yushi.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700948/rnwsk_rare_nct%20wish_sakuya.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwrk_ordinary_nct%20wish_riku.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwjh_unordinary_nct%20wish_jaehee.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwys_ordinary_nct%20wish_yushi.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwsn_unordinary_nct%20wish_sion.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700943/onwsn_ordinary_nct%20wish_sion.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700942/rnwry_rare_nct%20wish_ryo.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700935/unwry_unordinary_nct%20wish_ryo.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700934/rnwrk_rare_nct%20wish_riku.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/rnwys_rare_nct%20wish_yushi.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/onwjh_ordinary_nct%20wish_jaehee.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700928/onwry_ordinary_nct%20wish_ryo.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/rnwjh_rare_nct%20wish_jaehee.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/onwsk_ordinary_nct%20wish_sakuya.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700923/unwsk_unordinary_nct%20wish_sakuya.png",
+  "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700919/rnwsn_rare_nct%20wish_sion.png"
 ];
 
 // Helper function to map the card rarity to display names
@@ -28,10 +46,10 @@ function generateCards(imageUrls) {
     const card = {
       id: id,
       cardRarity: rarityMap[cardRarityKey.toLowerCase()],
-      //cardGroup: "placeholder",
-      cardGroup: cardGroupRaw.toLowerCase() === 'nct dream' ? 'NCT Dream' : cardGroupRaw.charAt(0).toUpperCase() + cardGroupRaw.slice(1),
+      cardGroup: "NCT WISH",
+      //cardGroup: cardGroupRaw.toLowerCase() === 'nct dream' ? 'NCT Dream' : cardGroupRaw.charAt(0).toUpperCase() + cardGroupRaw.slice(1),
       name: name === 'do' ? 'D.O.' : name.charAt(0).toUpperCase() + name.slice(1), // Capitalize name
-      group: "NCT placeholder", // DON'T FORGET TO CHANGE THIS FOR DIFFERENT GROUPS
+      group: "NCT", // DON'T FORGET TO CHANGE THIS FOR DIFFERENT GROUPS
       types: "", 
       rarity: "", 
       card_img: url
@@ -64,6 +82,7 @@ function generateCards(imageUrls) {
 
     
     // Why does this NCT lot have so many freakin members bloody hell
+    /*
     switch (name.toLowerCase()) {
       case "chenle":
         card.group = "NCT Dream";
@@ -108,7 +127,7 @@ function generateCards(imageUrls) {
         card.group = "NCT Dream";
         break;
       case "riku":
-        card.group = "NCT Dream";
+        card.group = "NCT WISH";
         break;
       case "ryo":
         card.group = "NCT WISH";
@@ -136,9 +155,11 @@ function generateCards(imageUrls) {
         break;
       case "yuta":
         card.group = "NCT NCT127";
-        break;               
+        break;
+      case "yushi":
+        card.group = "NCT WISH"               
       }
-      
+      */
 
     return card;
   });

--- a/src/lib/helpers/cardDataModifier.js
+++ b/src/lib/helpers/cardDataModifier.js
@@ -2,36 +2,2328 @@ import { writeFileSync } from 'fs';
 
 
 
-const cards = [];
+const cards = 
+[
+  {
+    "id": "osvdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881672/osvdk_ordinary_seventeen_dk.png"
+  },
+  {
+    "id": "o2svdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881629/o2svdk_ordinary_seventeen_dk.png"
+  },
+  {
+    "id": "osvdn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881688/osvdn_ordinary_seventeen_dino.png"
+  },
+  {
+    "id": "o2svdn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881649/o2svdn_ordinary_seventeen_dino.png"
+  },
+  {
+    "id": "osldn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866470/osldn_ordinary_soloist_dino.png"
+  },
+  {
+    "id": "osvhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881713/osvhs_ordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "o2svhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Grass"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881700/o2svhs_ordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "oslhs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866757/oslhs_ordinary_soloist_hoshi.png"
+  },
+  {
+    "id": "osvjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881776/osvjh_ordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "o2svjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881739/o2svjh_ordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "osvjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881787/osvjn_ordinary_seventeen_jun.png"
+  },
+  {
+    "id": "o2svjn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881762/o2svjn_ordinary_seventeen_jun.png"
+  },
+  {
+    "id": "osljn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867064/osljn_ordinary_soloist_jun.png"
+  },
+  {
+    "id": "osvjs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881827/osvjs_ordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "o2svjs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881816/o2svjs_ordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "osvmg",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881909/osvmg_ordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "o2svmg",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881849/o2svmg_ordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "osvsc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881952/osvsc_ordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "o2svsc",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881942/o2svsc_ordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "osvsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881896/osvsk_ordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "o2svsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881867/o2svsk_ordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "osvt8",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882713/osvt8_ordinary_seventeen_the8.png"
+  },
+  {
+    "id": "o2svt8",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881964/o2svt8_ordinary_seventeen_the8.png"
+  },
+  {
+    "id": "osvvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882738/osvvn_ordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "o2svvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882726/o2svvn_ordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "oslvn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869811/oslvn_ordinary_soloist_vernon.png"
+  },
+  {
+    "id": "osvwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882765/osvwo_ordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "o2svwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882754/o2svwo_ordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "o2svwz",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882790/o2svwz_ordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "osvwz",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882777/osvwz_ordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "oslwo",
+    "cardRarity": "Ordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870063/oslwo_ordinary_soloist_woozi.png"
+  },
+  {
+    "id": "usvdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880334/usvdk_unordinary_seventeen_dk.png"
+  },
+  {
+    "id": "u2svdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880301/u2svdk_unordinary_seventeen_dk.png"
+  },
+  {
+    "id": "usvdn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880416/usvdn_unordinary_seventeen_dino.png"
+  },
+  {
+    "id": "u2svdn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880380/u2svdn_unordinary_seventeen_dino.png"
+  },
+  {
+    "id": "usldn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866638/usldn_unordinary_soloist_dino.png"
+  },
+  {
+    "id": "usvhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Grass"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880619/usvhs_unordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "u2svhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880525/u2svhs_unordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "uslhs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866923/uslhs_unordinary_soloist_hoshi.png"
+  },
+  {
+    "id": "usvjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880706/usvjh_unordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "u2svjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880666/u2svjh_unordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "usvjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880893/usvjn_unordinary_seventeen_jun.png"
+  },
+  {
+    "id": "u2svjn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880785/u2svjn_unordinary_seventeen_jun.png"
+  },
+  {
+    "id": "usljn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869477/usljn_unordinary_soloist_jun.png"
+  },
+  {
+    "id": "usvjs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881082/usvjs_unordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "u2svjs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881018/u2svjs_unordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "usvmg",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881122/usvmg_unordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "u2svmg",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881111/u2svmg_unordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "usvsc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881217/usvsc_unordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "u2svsc",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881176/u2svsc_unordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "usvsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881164/usvsk_unordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "u2svsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881148/u2svsk_unordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "usvt8",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881267/usvt8_unordinary_seventeen_the8.png"
+  },
+  {
+    "id": "u2svt8",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881246/u2svt8_unordinary_seventeen_the8.png"
+  },
+  {
+    "id": "usvvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881302/usvvn_unordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "u2svvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881284/u2svvn_unordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "uslvn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869975/uslvn_unordinary_soloist_vernon.png"
+  },
+  {
+    "id": "usvwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881384/usvwo_unordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "u2svwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881341/u2svwo_unordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "usvwz",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Grass"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881398/usvwz_unordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "u2svwz",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881368/u2svwz_unordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "uslwo",
+    "cardRarity": "Unordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870191/uslwo_unordinary_soloist_woozi.png"
+  },
+  {
+    "id": "rsvdk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878819/rsvdk_rare_seventeen_dk.png"
+  },
+  {
+    "id": "r2svdk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878782/r2svdk_rare_seventeen_dk.png"
+  },
+  {
+    "id": "rsvdn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878929/rsvdn_rare_seventeen_dino.png"
+  },
+  {
+    "id": "r2svdn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878863/r2svdn_rare_seventeen_dino.png"
+  },
+  {
+    "id": "rsldn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866553/rsldn_rare_soloist_dino.png"
+  },
+  {
+    "id": "rsvhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879051/rsvhs_rare_seventeen_hoshi.png"
+  },
+  {
+    "id": "r2svhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878968/r2svhs_rare_seventeen_hoshi.png"
+  },
+  {
+    "id": "rslhs",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866810/rslhs_rare_soloist_hoshi.png"
+  },
+  {
+    "id": "rsvjh",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879115/rsvjh_rare_seventeen_jeonghan.png"
+  },
+  {
+    "id": "r2svjh",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879079/r2svjh_rare_seventeen_jeonghan.png"
+  },
+  {
+    "id": "rsvjn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879200/rsvjn_rare_seventeen_jun.png"
+  },
+  {
+    "id": "r2svjn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879151/r2svjn_rare_seventeen_jun.png"
+  },
+  {
+    "id": "rsljn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867167/rsljn_rare_soloist_jun.png"
+  },
+  {
+    "id": "rsvjs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879294/rsvjs_rare_seventeen_joshua.png"
+  },
+  {
+    "id": "r2svjs",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879238/r2svjs_rare_seventeen_joshua.png"
+  },
+  {
+    "id": "rsvmg",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879402/rsvmg_rare_seventeen_mingyu.png"
+  },
+  {
+    "id": "r2svmg",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879348/r2svmg_rare_seventeen_mingyu.png"
+  },
+  {
+    "id": "rsvsc",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879614/rsvsc_rare_seventeen_s.coups.png"
+  },
+  {
+    "id": "r2svsc",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879573/r2svsc_rare_seventeen_s.coups.png"
+  },
+  {
+    "id": "rsvsk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879531/rsvsk_rare_seventeen_seungkwan.png"
+  },
+  {
+    "id": "r2svsk",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879488/r2svsk_rare_seventeen_seungkwan.png"
+  },
+  {
+    "id": "rsvt8",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879692/rsvt8_rare_seventeen_the8.png"
+  },
+  {
+    "id": "r2svt8",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879655/r2svt8_rare_seventeen_the8.png"
+  },
+  {
+    "id": "rsvvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879784/rsvvn_rare_seventeen_vernon.png"
+  },
+  {
+    "id": "r2svvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879731/r2svvn_rare_seventeen_vernon.png"
+  },
+  {
+    "id": "rslvn",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869862/rslvn_rare_soloist_vernon.png"
+  },
+  {
+    "id": "rsvwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879946/rsvwo_rare_seventeen_wonwoo.png"
+  },
+  {
+    "id": "r2svwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879891/r2svwo_rare_seventeen_wonwoo.png"
+  },
+  {
+    "id": "rsvwz",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725880014/rsvwz_rare_seventeen_woozi.png"
+  },
+  {
+    "id": "r2svwz",
+    "cardRarity": "Rare",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725879982/r2svwz_rare_seventeen_woozi.png"
+  },
+  {
+    "id": "rslwo",
+    "cardRarity": "Rare",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870114/rslwo_rare_soloist_woozi.png"
+  },
+  {
+    "id": "ssvdk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877357/ssvdk_special_seventeen_dk.png"
+  },
+  {
+    "id": "s2svdk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877315/s2svdk_special_seventeen_dk.png"
+  },
+  {
+    "id": "ssvdn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877443/ssvdn_special_seventeen_dino.png"
+  },
+  {
+    "id": "s2svdn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877394/s2svdn_special_seventeen_dino.png"
+  },
+  {
+    "id": "ssldn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866596/ssldn_special_soloist_dino.png"
+  },
+  {
+    "id": "ssvhs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877716/ssvhs_special_seventeen_hoshi.png"
+  },
+  {
+    "id": "s2svhs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877672/s2svhs_special_seventeen_hoshi.png"
+  },
+  {
+    "id": "sslhs",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866863/sslhs_special_soloist_hoshi.png"
+  },
+  {
+    "id": "ssvjh",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877519/ssvjh_special_seventeen_jeonghan.png"
+  },
+  {
+    "id": "s2svjh",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877477/s2svjh_special_seventeen_jeonghan.png"
+  },
+  {
+    "id": "ssvjn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877620/ssvjn_special_seventeen_jun.png"
+  },
+  {
+    "id": "s2svjn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877565/s2svjn_special_seventeen_jun.png"
+  },
+  {
+    "id": "ssljn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867249/ssljn_special_soloist_jun.png"
+  },
+  {
+    "id": "ssvjs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877836/ssvjs_special_seventeen_joshua.png"
+  },
+  {
+    "id": "s2svjs",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877774/s2svjs_special_seventeen_joshua.png"
+  },
+  {
+    "id": "ssvmg",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877936/ssvmg_special_seventeen_mingyu.png"
+  },
+  {
+    "id": "s2svmg",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877892/s2svmg_special_seventeen_mingyu.png"
+  },
+  {
+    "id": "ssvsc",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878092/ssvsc_special_seventeen_s.coups.png"
+  },
+  {
+    "id": "s2svsc",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878053/s2svsc_special_seventeen_s.coups.png"
+  },
+  {
+    "id": "ssvsk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878016/ssvsk_special_seventeen_seungkwan.png"
+  },
+  {
+    "id": "s2svsk",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725877981/s2svsk_special_seventeen_seungkwan.png"
+  },
+  {
+    "id": "ssvt8",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878186/ssvt8_special_seventeen_the8.png"
+  },
+  {
+    "id": "s2svt8",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878142/s2svt8_special_seventeen_the8.png"
+  },
+  {
+    "id": "ssvvn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878291/ssvvn_special_seventeen_vernon.png"
+  },
+  {
+    "id": "s2svvn",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878247/s2svvn_special_seventeen_vernon.png"
+  },
+  {
+    "id": "sslvn",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869905/sslvn_special_soloist_vernon.png"
+  },
+  {
+    "id": "ssvwo",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878460/ssvwo_special_seventeen_wonwoo.png"
+  },
+  {
+    "id": "s2svwo",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878427/s2svwo_special_seventeen_wonwoo.png"
+  },
+  {
+    "id": "ssvwz",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878553/ssvwz_special_seventeen_woozi.png"
+  },
+  {
+    "id": "s2svwz",
+    "cardRarity": "Special",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725878509/s2svwz_special_seventeen_woozi.png"
+  },
+  {
+    "id": "sslwo",
+    "cardRarity": "Special",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870150/sslwo_special_soloist_woozi.png"
+  },
+  {
+    "id": "esvdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875755/esvdk_extraordinary_seventeen_dk.png"
+  },
+  {
+    "id": "e2svdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874644/e2svdk_extraordinary_seventeen_dk.png"
+  },
+  {
+    "id": "esvdn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875838/esvdn_extraordinary_seventeen_dino.png"
+  },
+  {
+    "id": "e2svdn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874743/e2svdn_extraordinary_seventeen_dino.png"
+  },
+  {
+    "id": "esldn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866402/esldn_extraordinary_soloist_dino.png"
+  },
+  {
+    "id": "esvhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876094/esvhs_extraordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "e2svhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874888/e2svhs_extraordinary_seventeen_hoshi.png"
+  },
+  {
+    "id": "eslhs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725866706/eslhs_extraordinary_soloist_hoshi.png"
+  },
+  {
+    "id": "esvjh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Psychic"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876198/esvjh_extraordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "e2svjh",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725874974/e2svjh_extraordinary_seventeen_jeonghan.png"
+  },
+  {
+    "id": "esvjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876257/esvjn_extraordinary_seventeen_jun.png"
+  },
+  {
+    "id": "e2svjn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875068/e2svjn_extraordinary_seventeen_jun.png"
+  },
+  {
+    "id": "esljn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725867013/esljn_extraordinary_soloist_jun.png"
+  },
+  {
+    "id": "esvjs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876311/esvjs_extraordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "e2svjs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875137/e2svjs_extraordinary_seventeen_joshua.png"
+  },
+  {
+    "id": "esvmg",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876404/esvmg_extraordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "e2svmg",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875297/e2svmg_extraordinary_seventeen_mingyu.png"
+  },
+  {
+    "id": "esvsc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Psychic"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876504/esvsc_extraordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "e2svsc",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875427/e2svsc_extraordinary_seventeen_s.coups.png"
+  },
+  {
+    "id": "esvsk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876558/esvsk_extraordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "e2svsk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875396/e2svsk_extraordinary_seventeen_seungkwan.png"
+  },
+  {
+    "id": "esvt8",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876619/esvt8_extraordinary_seventeen_the8.png"
+  },
+  {
+    "id": "e2svt8",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875503/e2svt8_extraordinary_seventeen_the8.png"
+  },
+  {
+    "id": "esvvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876659/esvvn_extraordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "e2svvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875560/e2svvn_extraordinary_seventeen_vernon.png"
+  },
+  {
+    "id": "eslvn",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725869716/eslvn_extraordinary_soloist_vernon.png"
+  },
+  {
+    "id": "esvwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876708/esvwo_extraordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "e2svwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875636/e2svwo_extraordinary_seventeen_wonwoo.png"
+  },
+  {
+    "id": "esvwz",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725876753/esvwz_extraordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "e2svwz",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Seventeen",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725875673/e2svwz_extraordinary_seventeen_woozi.png"
+  },
+  {
+    "id": "eslwo",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "Soloist",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725870022/eslwo_extraordinary_soloist_woozi.png"
+  },
+  {
+    "id": "fethju",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pfriendship Event",
+    "name": "The8 & Jun",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886196/fethju_priceless_Pfriendship%20Event_the8_jun.png"
+  },
+  {
+    "id": "fesemo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Friendship Event",
+    "name": "Moonbin & Seungkwan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725886060/fesemo_priceless_Friendship%20Event_moonbin_seungkwan.png"
+  },
+  {
+    "id": "amedkk",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871725/amedkk_priceless_amethyst_dk.png"
+  },
+  {
+    "id": "paqdk",
+    "cardRarity": "Priceless",
+    "cardGroup": "Aphrodite",
+    "name": "DK",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871797/paqdk_priceless_aphrodite_dk.png"
+  },
+  {
+    "id": "amedin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871882/amedin_priceless_amethyst_dino.png"
+  },
+  {
+    "id": "sumdin",
+    "cardRarity": "Priceless",
+    "cardGroup": "Summer Event Bsummer",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725871949/sumdin_priceless_bsummer_dino.png"
+  },
+  {
+    "id": "xodin",
+    "cardRarity": "Priceless",
+    "cardGroup": "XOXO Event",
+    "name": "Dino",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872528/xodin_priceless_XOXO_dino.png"
+  },
+  {
+    "id": "alehos",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725872603/alehos_priceless_alexandrite_hoshi.png"
+  },
+  {
+    "id": "apfshi",
+    "cardRarity": "Priceless",
+    "cardGroup": "April Fools Event Apf",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873104/apfshi_priceless_apf_hoshi.png"
+  },
+  {
+    "id": "xmhsi",
+    "cardRarity": "Priceless",
+    "cardGroup": "Xmas Xmas23",
+    "name": "Hoshi",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873202/xmhsi_priceless_xmas23_hoshi.png"
+  },
+  {
+    "id": "evghan",
+    "cardRarity": "Priceless",
+    "cardGroup": "Evil Event",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873300/evghan_priceless_evil_jeonghan.png"
+  },
+  {
+    "id": "faejhn",
+    "cardRarity": "Priceless",
+    "cardGroup": "Fairy Fairies Event Bfairies",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873347/faejhn_priceless_bfairies_jeonghan.png"
+  },
+  {
+    "id": "libjeo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Libra",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873457/libjeo_priceless_libra_jeonghan.png"
+  },
+  {
+    "id": "royhan",
+    "cardRarity": "Priceless",
+    "cardGroup": "Royal Event",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873512/royhan_priceless_Royal%20Event_jeonghan.png"
+  },
+  {
+    "id": "hbdpocket",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Jeonghan",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725873402/hbdpocket_priceless_Staff%20Birthday_jeonghan.png"
+  },
+  {
+    "id": "alejun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Alexandrite",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725881927/alejun_priceless_alexandrite_jun.png"
+  },
+  {
+    "id": "srojun",
+    "cardRarity": "Priceless",
+    "cardGroup": "Psanrio",
+    "name": "Jun",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882042/srojun_priceless_psanrio_jun.png"
+  },
+  {
+    "id": "hbdsophiya",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882710/hbdsophiya_priceless_Staff%20Birthday_joshua.png"
+  },
+  {
+    "id": "hbdsophiya2",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729778645/hbdsophiya2_priceless_staff%20birthday_joshua.png"
+  },
+  {
+    "id": "hbdcami",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882512/hbdcami_priceless_Staff%20Birthday_joshua.png"
+  },
+  {
+    "id": "sfmami",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate Event",
+    "name": "Joshua",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725882760/sfmami_priceless_staffmate_joshua.png"
+  },
+  {
+    "id": "zuhmgy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pcardcaptor",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883130/zuhmgy_priceless_pcardcaptor_mingyu.png"
+  },
+  {
+    "id": "diagyu",
+    "cardRarity": "Priceless",
+    "cardGroup": "Diamond",
+    "name": "Mingyu",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883074/diagyu_priceless_diamond_mingyu.png"
+  },
+  {
+    "id": "btasco",
+    "cardRarity": "Priceless",
+    "cardGroup": "BTA",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883258/btasco_priceless_BTA_s.coups.png"
+  },
+  {
+    "id": "leoups",
+    "cardRarity": "Priceless",
+    "cardGroup": "Leo",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883364/leoups_priceless_leo_s.coups.png"
+  },
+  {
+    "id": "sarsco",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sardonyx",
+    "name": "S.Coups",
+    "group": "Seventeen",
+    "types": ["Dragon"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883470/sarsco_priceless_sardonyx_s.coups.png"
+  },
+  {
+    "id": "hbdtellie",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Seungkwan",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883556/hbdtellie_priceless_Staff%20Birthday_seungkwan.png"
+  },
+  {
+    "id": "cdythe",
+    "cardRarity": "Priceless",
+    "cardGroup": "Candy Event Bcandy",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883864/cdythe_priceless_bcandy_the8.png"
+  },
+  {
+    "id": "scothe",
+    "cardRarity": "Priceless",
+    "cardGroup": "Scorpio",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883960/scothe_priceless_scorpio_the8.png"
+  },
+  {
+    "id": "pset8",
+    "cardRarity": "Priceless",
+    "cardGroup": "Stardust Event",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883902/pset8_priceless_Stardust%20Event_the8.png"
+  },
+  {
+    "id": "tyuth8",
+    "cardRarity": "Priceless",
+    "cardGroup": "Pthanku",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884091/tyuth8_priceless_pthanku_the8.png"
+  },
+  {
+    "id": "amever",
+    "cardRarity": "Priceless",
+    "cardGroup": "Amethyst",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Psychic"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884165/amever_priceless_amethyst_vernon.png"
+  },
+  {
+    "id": "apover",
+    "cardRarity": "Priceless",
+    "cardGroup": "Apocalypse Event Papocalypse",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884197/apover_priceless_papocalypse_vernon.png"
+  },
+  {
+    "id": "sfmshy",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate Event",
+    "name": "Vernon",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884239/sfmshy_priceless_staffmate_vernon.png"
+  },
+  {
+    "id": "canwon",
+    "cardRarity": "Priceless",
+    "cardGroup": "Cancer",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884302/canwon_priceless_cancer_wonwoo.png"
+  },
+  {
+    "id": "ubywoo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Ruby",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884378/ubywoo_priceless_ruby_wonwoo.png"
+  },
+  {
+    "id": "slmwwo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Soulmate Event",
+    "name": "Wonwoo",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884344/slmwwo_priceless_soulmate_wonwoo.png"
+  },
+  {
+    "id": "sagwoo",
+    "cardRarity": "Priceless",
+    "cardGroup": "Sagittarius",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Lightning"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884487/sagwoo_priceless_sagittarius_woozi.png"
+  },
+  {
+    "id": "hbdlou",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staff Birthday",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Water"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884439/hbdlou_priceless_Staff%20Birthday_woozi.png"
+  },
+  {
+    "id": "sfmnco",
+    "cardRarity": "Priceless",
+    "cardGroup": "Staffmate Event",
+    "name": "Woozi",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884529/sfmnco_priceless_staffmate_woozi.png"
+  },
+  {
+    "id": "ansvbcs",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Vernon & Dino & Seungkwan & BooChanSol",
+    "group": "Seventeen",
+    "types": ["Grass"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885647/ansvbcs_altair_anniversary_Vernon%20Dino%20Seungkwan.png"
+  },
+  {
+    "id": "ansvjc",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "S.Coups & Jeonghan & JeongCheol",
+    "group": "Seventeen",
+    "types": ["Fire"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885527/ansvjc_altair_anniversary_S.Coups%20Jeonghan.png",
+    "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
+  },
+  {
+    "id": "ansvsh",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Hoshi & Woozi & SoonHoon",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885425/ansvsh_altair_anniversary_Hoshi%20Woozi.png"
+  },
+  {
+    "id": "ansvss",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Seungkwan & DK & SeokSoo",
+    "group": "Seventeen",
+    "types": ["Fighting"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885187/ansvss_altair_anniversary_Seungkwan%20DK.png",
+    "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
+  },
+  {
+    "id": "ansvmw",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Mingyu & Wonwoo & MinWon",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Amazing Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725885017/ansvmw_altair_anniversary_Mingyu%20Wonwoo.png",
+    "foil":"https://res.cloudinary.com/djg9bhuwi/image/upload/v1725213270/card_foil_v3.png"
+  },
+  {
+    "id": "ansvjh",
+    "cardRarity": "Altair",
+    "cardGroup": "Anniversary",
+    "name": "Jun & The8 & JunHao",
+    "group": "Seventeen",
+    "types": ["Grass"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725884947/ansvjh_altair_anniversary_Jun%20The8.png"
+  },
+  {
+    "id": "foolpic",
+    "cardRarity": "Altair",
+    "cardGroup": "Fools",
+    "name": "Pi Cheolin & Dino",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Trainer Gallery Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887787/foolpic_altair_fools_Pi%20Cheolin_dino.png"
+  },
+  {
+    "id": "kittyjayjun",
+    "cardRarity": "Altair",
+    "cardGroup": "Kitties",
+    "name": "Jay & Jun",
+    "group": "Seventeen",
+    "types": ["Metal"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887398/kittyjayjun_altair_kitties_Jay%20Jun.png"
+  },
+  {
+    "id": "xmasseoksoo",
+    "cardRarity": "Altair",
+    "cardGroup": "Xmas",
+    "name": "Joshua & DK & SeokSoo",
+    "group": "Seventeen",
+    "types": ["Fairy"],
+    "rarity": "Rare Shiny",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725887721/xmasseoksoo_altair_xmas_Joshua%20DK.png"
+  },
+  {
+    "id": "woofhao",
+    "cardRarity": "Altair",
+    "cardGroup": "Wild Animal",
+    "name": "The8",
+    "group": "Seventeen",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo VSTAR",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725883672/woofhao_altair_Wild%20Animal_the8.png"
+  },
+  {
+    "id": "obsdk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "BSS",
+    "types": ["Darkness"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864973/obsdk_ordinary_BSS_dk.png"
+  },
+  {
+    "id": "obshs",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "BSS",
+    "types": ["Darkness"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865054/obshs_ordinary_BSS_hoshi.png"
+  },
+  {
+    "id": "obssk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "BSS",
+    "types": ["Darkness"],
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865120/oBSSk_ordinary_BSS_seungkwan.png"
+  },
+  {
+    "id": "ubsdk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "BSS",
+    "types": ["Metal"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865521/ubsdk_unordinary_BSS_dk.png"
+  },
+  {
+    "id": "ubshs",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "BSS",
+    "types": ["Psychic"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865576/ubshs_unordinary_BSS_hoshi.png"
+  },
+  {
+    "id": "ubssk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "BSS",
+    "types": ["Fighting"],
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865620/uBSSk_unordinary_BSS_seungkwan.png"
+  },
+  {
+    "id": "rbsdk",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "BSS",
+    "types": ["Darkness"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865174/rbsdk_rare_BSS_dk.png"
+  },
+  {
+    "id": "rbshs",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "BSS",
+    "types": ["Water"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865221/rbshs_rare_BSS_hoshi.png"
+  },
+  {
+    "id": "rbssk",
+    "cardRarity": "Rare",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "BSS",
+    "types": ["Fire"],
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865270/rBSSk_rare_BSS_seungkwan.png"
+  },
+  {
+    "id": "sbsdk",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "BSS",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865328/sbsdk_special_BSS_dk.png"
+  },
+  {
+    "id": "sbshs",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "BSS",
+    "types": ["Lightning"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865394/sbshs_special_BSS_hoshi.png"
+  },
+  {
+    "id": "sbssk",
+    "cardRarity": "Special",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "BSS",
+    "types": ["Grass"],
+    "rarity": "Rare Holo Cosmos",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725865457/sBSSk_special_BSS_seungkwan.png"
+  },
+  {
+    "id": "ebsdk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "DK",
+    "group": "BSS",
+    "types": ["Fighting"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864332/ebsdk_extraordinary_BSS_dk.png"
+  },
+  {
+    "id": "ebshs",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "Hoshi",
+    "group": "BSS",
+    "types": ["Metal"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864845/ebshs_extraordinary_BSS_hoshi.png"
+  },
+  {
+    "id": "ebssk",
+    "cardRarity": "Extraordinary",
+    "cardGroup": "BSS",
+    "name": "Seungkwan",
+    "group": "BSS",
+    "types": ["Fighting"],
+    "rarity": "Radiant Rare",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1725864925/eBSSk_extraordinary_BSS_seungkwan.png"
+  }
+]
+;
 
+function addNewFields(cards) {
+  return cards.map(card => {
+
+    if (card.cardGroup === "Alexandrite" || card.cardGroup === "Amethyst" || card.cardGroup === "Aquamarine" ||
+    card.cardGroup === "Diamond" || card.cardGroup === "Emerald" || card.cardGroup === "Ruby" || card.cardGroup === "Sapphire"
+    || card.cardGroup === "Sardonyx") {
+      card.category = "Gemstone";
+      card.keyword = "Event ";
+    }
+    else if (card.cardGroup === "Cancer" || card.cardGroup === "Leo" || card.cardGroup === "Libra" ||
+    card.cardGroup === "Sagittarius" || card.cardGroup === "Scorpio" || card.cardGroup === "Virgo") {
+      card.category = "Event";
+      card.keyword = "Zodiac ";
+    }
+    else if (card.cardRarity === "Priceless" || card.cardRarity === "Altair") {
+      card.category = "Event";
+      card.keyword = "";
+    }
+    else {
+      card.category = "Regular";
+      card.keyword = "";
+    }
+
+    
+    return card;
+  })
+}
+
+let m_cards = addNewFields(cards);
 
 // Modify the data
-cards.forEach(card => {
+m_cards.forEach(card => {
+
+  if (card.cardGroup === "BSS") {
+    card.group = "Seventeen";
+  }
+  card.keyword += "SVT"
+
+  if (card.name === "S.Coups") {
+    card.keyword += " scoups";
+  }
+
   if (card.name === "Mark" || card.name === "Haechan") {
-    card.group = "NCT Dream NCT127";
+    card.group = "NCT";
+
+    if (card.cardGroup != "NCT Dream") {
+      card.keyword += "Dream"
+    }
+
+    if (card.cardGroup != "NCT127") {
+      card.keyword += " NCT127"
+    }
+    card.keyword += " 127";
+    
   }
   else if (card.name === "Chenle" || card.name === "Jaemin" || card.name === "Jeno" || card.name === "Jisung"
-  || card.name === "Renjun" || card.name === "Riku") {
-    card.group = "NCT Dream";
+  || card.name === "Renjun") {
+    card.group = "NCT";
+    if (card.cardGroup != "NCT Dream") {
+      card.keyword += "Dream";
+    }
+    
   }
-  else if (card.name === "Jaehee" || card.name === "Ryo" || card.name === "Sakuya" || card.name === "Sion") {
-    card.group = "NCT WISH";
+  else if (card.name === "Jaehee" || card.name === "Riku"|| card.name === "Ryo" || 
+  card.name === "Sakuya" || card.name === "Sion") {
+    card.group = "NCT";
+    if (card.cardGroup != "NCT WISH") {
+      card.keyword += "WISH";
+    }
   }
   else if (card.name === "Doyoung" || card.name === "Jaehyun" || card.name === "Johnny" || card.name === "Jungwoo"
   || card.name === "Taeyong" || card.name === "Yuta") {
-    card.group = "NCT NCT127";
-  }
-  else if (card.name === "Winwin") {
-    card.group = "NCT WayV NCT127";
+    card.group = "NCT";
+    if (card.cardGroup != "NCT127") {
+      card.keyword += "NCT127";
+    }
+    card.keyword += " 127";
+    
   }
   else if (card.name === "Hendery" || card.name === "Kun" || card.name === "Ten" || card.name === "Xiaojun"
-  || card.name === "Yangyang" || card.name === "Riku") {
-    card.group = "NCT WayV";
+  || card.name === "Yangyang" || card.name === "Riku" || card.name === "Winwin") {
+    // WinWin is not of NCT127 anymore, I suppose?
+
+    if (card.name === "Winwin") {
+      card.name = "WinWin";
+    }
+
+    card.group = "NCT";
+
+    if (card.cardGroup != "WayV") {
+      card.keyword += "WayV";
+    }
+    
   }
+
+  if (card.cardGroup == "Staffmate Event") {
+    card.cardGroup = "Staffmate";
+    card.keyword += " Staff Mate";
+  }
+  else if (card.cardGroup == "Soulmate Event") {
+    card.cardGroup = "Soulmate"
+    card.keyword += " Soul Mate";
+  }
+  else if (card.cardGroup == "Apocalypse Event") {
+    card.cardGroup = "Apocalypse";
+  }
+
+
 });
 
 
-const jsonContent = JSON.stringify(cards, null, 2);
+
+
+const jsonContent = JSON.stringify(m_cards, null, 2);
 
 //Write the JSON string to a file named 'sorted_cards.json'
 writeFileSync('modified_cards.json', jsonContent, 'utf-8');

--- a/src/lib/helpers/cardReorder.js
+++ b/src/lib/helpers/cardReorder.js
@@ -1,15 +1,197 @@
 import { writeFileSync } from 'fs';
 
-//const cards = require('src/lib/database/nctLibrary.json');
-const cards = require('./card_data.json');
-  
+const cards =
+[
+  {
+    "id": "unwrk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwrk_unordinary_nct%20wish_riku.png"
+  },
+  {
+    "id": "unwys",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwys_unordinary_nct%20wish_yushi.png"
+  },
+  {
+    "id": "rnwsk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700948/rnwsk_rare_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "onwrk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwrk_ordinary_nct%20wish_riku.png"
+  },
+  {
+    "id": "unwjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwjh_unordinary_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "onwys",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwys_ordinary_nct%20wish_yushi.png"
+  },
+  {
+    "id": "unwsn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwsn_unordinary_nct%20wish_sion.png"
+  },
+  {
+    "id": "onwsn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700943/onwsn_ordinary_nct%20wish_sion.png"
+  },
+  {
+    "id": "rnwry",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700942/rnwry_rare_nct%20wish_ryo.png"
+  },
+  {
+    "id": "unwry",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700935/unwry_unordinary_nct%20wish_ryo.png"
+  },
+  {
+    "id": "rnwrk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700934/rnwrk_rare_nct%20wish_riku.png"
+  },
+  {
+    "id": "rnwys",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/rnwys_rare_nct%20wish_yushi.png"
+  },
+  {
+    "id": "onwjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/onwjh_ordinary_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "onwry",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700928/onwry_ordinary_nct%20wish_ryo.png"
+  },
+  {
+    "id": "rnwjh",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/rnwjh_rare_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "onwsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/onwsk_ordinary_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "unwsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700923/unwsk_unordinary_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "rnwsn",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700919/rnwsn_rare_nct%20wish_sion.png"
+  }
+]
+;
+
   // Define the order for each property
   //const groupOrder = ["EXO", "EXO-CBX", "EXO-SC", "SuperM", "Soloist"];
-  const groupOrder = ["NCT127", "NCT Dream", "WayV", "KUN&XIAOJUN", "Soloist"];
+  const groupOrder = ["NCT127", "NCT Dream", "WayV", "KUN&XIAOJUN", "NCT WISH", "Soloist"];
   const rarityOrder = ["Ordinary", "Unordinary", "Rare", "Special", "Extraordinary", "Priceless", "Altair"];
   //const nameOrder = ["Baekhyun", "Chen", "Chanyeol", "D.O.", "Kai", "Lay", "Luhan", "Sehun", "Suho", "Tao", "Xiumin"];
-  const nameOrder = ["Chenle", "Doyoung", "Haechan", "Hendery", "Jaehyun", "Jaemin", "Jeno", "Jisung", "Johnny", "Jungwoo",
-  "Kun", "Mark", "Renjun", "Riku", "Ryo", "Sakuya", "Sion", "Taeyong", "Ten", "Winwin", "Xiaojun", "Yangyang", "Yuta"];
+  const nameOrder = ["Chenle", "Doyoung", "Haechan", "Hendery", "Jaehee", "Jaehyun", "Jaemin", "Jeno", "Jisung", "Johnny", "Jungwoo",
+  "Kun", "Mark", "Renjun", "Riku", "Ryo", "Sakuya", "Sion", "Taeyong", "Ten", "Winwin", "Xiaojun", "Yangyang", "Yushi", "Yuta"];
 
   // Sorting
   cards.sort((a, b) => {

--- a/src/lib/helpers/sorted_cards.json
+++ b/src/lib/helpers/sorted_cards.json
@@ -1,0 +1,182 @@
+[
+  {
+    "id": "onwjh",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/onwjh_ordinary_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "onwrk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwrk_ordinary_nct%20wish_riku.png"
+  },
+  {
+    "id": "onwry",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700928/onwry_ordinary_nct%20wish_ryo.png"
+  },
+  {
+    "id": "onwsk",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/onwsk_ordinary_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "onwsn",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700943/onwsn_ordinary_nct%20wish_sion.png"
+  },
+  {
+    "id": "onwys",
+    "cardRarity": "Ordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Common",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/onwys_ordinary_nct%20wish_yushi.png"
+  },
+  {
+    "id": "unwjh",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwjh_unordinary_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "unwrk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwrk_unordinary_nct%20wish_riku.png"
+  },
+  {
+    "id": "unwry",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700935/unwry_unordinary_nct%20wish_ryo.png"
+  },
+  {
+    "id": "unwsk",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700923/unwsk_unordinary_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "unwsn",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700945/unwsn_unordinary_nct%20wish_sion.png"
+  },
+  {
+    "id": "unwys",
+    "cardRarity": "Unordinary",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Secret",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700951/unwys_unordinary_nct%20wish_yushi.png"
+  },
+  {
+    "id": "rnwjh",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Jaehee",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700926/rnwjh_rare_nct%20wish_jaehee.png"
+  },
+  {
+    "id": "rnwrk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Riku",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700934/rnwrk_rare_nct%20wish_riku.png"
+  },
+  {
+    "id": "rnwry",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Ryo",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700942/rnwry_rare_nct%20wish_ryo.png"
+  },
+  {
+    "id": "rnwsk",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sakuya",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700948/rnwsk_rare_nct%20wish_sakuya.png"
+  },
+  {
+    "id": "rnwsn",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Sion",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700919/rnwsn_rare_nct%20wish_sion.png"
+  },
+  {
+    "id": "rnwys",
+    "cardRarity": "Rare",
+    "cardGroup": "NCT WISH",
+    "name": "Yushi",
+    "group": "NCT",
+    "types": "",
+    "rarity": "Rare Holo",
+    "card_img": "https://res.cloudinary.com/djg9bhuwi/image/upload/v1729700930/rnwys_rare_nct%20wish_yushi.png"
+  }
+]


### PR DESCRIPTION
Noticed that new NCT WISH cards were not actually added to the json file... :/

Added two new json fields: "category" and "keyword"
Json files will look less messier, hopefully.

"category": Card categories. Regular or Event or Gemstone.
"keyword": Search keywords.


QOL update:

Seventeen
- 'svt' and 'seventeen' are both usable keywords.
- 'scoups' and 's.coups' are both usable keywords.

NCT
- xm127 group card is searchable with the keyword 'group'
- '127' and 'nct127' are both usable keywords.

Event cards
- All gemstone cards are searchable with the keyword 'gemstone'
- All zodiac sign cards are searchable with the keyword 'zodiac'
- All Xmas Event cards are searchable with the following keywords: 'xmas,' 'christmas'
- April Fools Event: 'april' 'fools'
- etc.
